### PR TITLE
  Add minimal Dockerfile and docker-compose.yml for containerized deploy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.pyc
+*.pyo
+*.db
+.git
+.gitignore
+tests/
+database/
+documents/
+uv.lock 

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ tests/data/
 
 # environment variables
 .env
+
+# dirs we might mount in docker-compose.yml
+documents/
+database/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.11-slim
+
+# Install uv using pip instead of the shell installer - to avoid platform issues
+RUN pip install uv
+
+# Set working directory
+WORKDIR /app
+
+# Copy project files
+COPY . .
+
+# Install the package
+RUN uv pip install --system .
+
+# Create directories for mounts
+RUN mkdir -p /inbound /database /ollama/models
+
+# Set environment variables
+ENV MONITOR_DIRECTORIES="/inbound"
+ENV EMBEDDINGS_PROVIDER="ollama"
+ENV EMBEDDINGS_MODEL="mxbai-embed-large"
+ENV EMBEDDINGS_VECTOR_DIM=1024
+
+# Expose port
+EXPOSE 8000
+
+# Default command
+CMD ["uv", "run", "haiku-rag", "serve", "--db", "/database/haiku-rag.db"]

--- a/README.md
+++ b/README.md
@@ -192,3 +192,36 @@ async with HaikuRAG("database.db") as client:
         print(f"Content: {chunk.content}")
         print(f"From document: {chunk.document_id}")
 ```
+
+## Docker
+
+``` bash
+docker pull topiaruss/haiku-rag:latest
+docker compose up
+```
+
+### docker-compose.yml file
+
+ * When this runs, a documents directory will be created in this directory. You can drag files here to be indexed.
+
+ * A database directory will be created to hold your haiku-rag.db.
+
+ * The compose file mounts your local `~/.ollama/models` directory into which you should pull in the normal way the models you want to use. These will then be accessible inside the running container.
+
+For production, expect to edit the docker-compose.yml file 
+to set a permanent location for your models, database, and document directory. 
+
+Consult Docker resources to understand the many possibilities.
+
+
+### build-multiplatform.sh
+
+This is a simple builder to provide a multi-platform image.
+Replace "topiaruss" with your own dockerhub username, create the haiku-rag 
+image folder, and issue a `docker login` command
+
+### check (tail) the logs
+
+```bash
+docker compose logs -f
+```

--- a/build-multiplatform.sh
+++ b/build-multiplatform.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Create a new builder instance for multi-platform builds
+docker buildx create --name multiplatform-builder --use --bootstrap
+
+# Build for both AMD64 and ARM64 platforms
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  --tag topiaruss/haiku-rag:latest \
+  --push \
+  .
+
+echo "The Multi-platform build is nowcomplete for linux/amd64 and linux/arm64"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  haiku-rag:
+    build: .
+    image: topiaruss/haiku-rag:latest
+    ports:
+      - "8000:8000"
+    volumes:
+      # Mount external directory to /inbound for document monitoring
+      - ./documents:/inbound
+      # Mount database directory for persistence
+      - ./database:/database
+      # Mount ollama models directory (adjust path as needed)
+      - ~/.ollama/models:/ollama/models
+    environment:
+      - MONITOR_DIRECTORIES=/inbound
+      - EMBEDDINGS_PROVIDER=ollama
+      - EMBEDDINGS_MODEL=mxbai-embed-large
+      - EMBEDDINGS_VECTOR_DIM=1024
+      - OLLAMA_BASE_URL=http://host.docker.internal:11434
+    restart: unless-stopped


### PR DESCRIPTION
A minimal approach to a multiplatform docker build. 

Currently the build script targets `topiaruss` - my account. You will not be able to push there, so choose another destination. There are a couple of occurences of that string, BTW

The build worked for me on an M3 mac. It is not yet tested on amd64. 

My testing was limited to `haiku-rag serve` which indexed a few docs. 

You can take it from there. Happy to help further...