### PR TITLE
Additional options for document conversion with docling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,20 @@
 # Changelog
 ## [Unreleased]
 
+### Added
+
+- **Conversion Options**: Fine-grained control over document conversion for both local and remote converters
+  - New `conversion_options` config section in `ProcessingConfig`
+  - OCR settings: `do_ocr`, `force_ocr`, `ocr_lang` for controlling OCR behavior
+  - Table extraction: `do_table_structure`, `table_mode` (fast/accurate), `table_cell_matching`
+  - Image settings: `images_scale` to control image resolution
+  - Options work identically with both `docling-local` and `docling-serve` converters
+
 ### Changed
 
 - Increase reranking candidate retrieval multiplier from 3x to 10x for improved result quality
 - **Docker Images**: Main `haiku.rag` image no longer automatically built and published
+- **Conversion Options**: Removed the legacy `pdf_backend` setting; docling now chooses the optimal backend automatically
 
 ## [0.17.0] - 2025-11-17
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,6 +104,14 @@ processing:
   chunking_merge_peers: true
   chunking_use_markdown_tables: false
   markdown_preprocessor: ""
+  conversion_options:
+    do_ocr: true
+    force_ocr: false
+    ocr_lang: []
+    do_table_structure: true
+    table_mode: accurate
+    table_cell_matching: true
+    images_scale: 2.0
 
 providers:
   ollama:
@@ -236,7 +244,63 @@ processing:
   chunking_tokenizer: "Qwen/Qwen3-Embedding-0.6B"  # HuggingFace model for tokenization
   chunking_merge_peers: true                 # Merge undersized successive chunks
   chunking_use_markdown_tables: false        # Use markdown tables vs narrative format
+
+  # Conversion options (works with both local and remote converters)
+  conversion_options:
+    # OCR settings
+    do_ocr: true                             # Enable OCR for bitmap content
+    force_ocr: false                         # Replace existing text with OCR
+    ocr_lang: []                             # OCR languages (e.g., ["en", "fr", "de"])
+
+    # Table extraction
+    do_table_structure: true                 # Extract table structure
+    table_mode: accurate                     # fast or accurate
+    table_cell_matching: true                # Match table cells back to PDF cells
+
+    # Image settings
+    images_scale: 2.0                        # Image scale factor
 ```
+
+### Conversion Options
+
+The `conversion_options` section allows fine-grained control over document conversion. These options work with both `docling-local` and `docling-serve` converters.
+
+#### OCR Settings
+
+```yaml
+conversion_options:
+  do_ocr: true          # Enable OCR for bitmap/scanned content
+  force_ocr: false      # Replace all text with OCR output
+  ocr_lang: []          # List of OCR languages, e.g., ["en", "fr", "de"]
+```
+
+- **do_ocr**: When `true`, applies OCR to images and scanned pages. Disable for faster processing if documents contain only native text.
+- **force_ocr**: When `true`, replaces existing text layers with OCR output. Useful for documents with poor text extraction.
+- **ocr_lang**: List of language codes for OCR. Empty list uses default language detection. Examples: `["en"]`, `["en", "fr", "de"]`.
+
+#### Table Extraction
+
+```yaml
+conversion_options:
+  do_table_structure: true    # Extract structured table data
+  table_mode: accurate        # fast or accurate
+  table_cell_matching: true   # Match cells back to PDF
+```
+
+- **do_table_structure**: When `true`, extracts table structure. Disable for faster processing if tables aren't important.
+- **table_mode**:
+  - `accurate`: Better table structure recognition (slower)
+  - `fast`: Faster processing with simpler table detection
+- **table_cell_matching**: When `true`, matches detected table cells back to PDF cells. Disable if tables have merged cells across columns.
+
+#### Image Settings
+
+```yaml
+conversion_options:
+  images_scale: 2.0  # Image resolution scale factor
+```
+
+- **images_scale**: Scale factor for extracted images. Higher values = better quality but larger size. Typical range: 1.0-3.0.
 
 ### Local vs Remote Processing
 
@@ -265,6 +329,8 @@ providers:
     api_key: "your-api-key"  # Optional
     timeout: 300              # Request timeout in seconds
 ```
+
+Conversion options work identically for both local and remote processing.
 
 ### Chunking Strategies
 

--- a/haiku_rag_slim/haiku/rag/config/__init__.py
+++ b/haiku_rag_slim/haiku/rag/config/__init__.py
@@ -8,6 +8,7 @@ from haiku.rag.config.loader import (
 from haiku.rag.config.models import (
     AGUIConfig,
     AppConfig,
+    ConversionOptions,
     EmbeddingsConfig,
     LanceDBConfig,
     MonitorConfig,
@@ -25,6 +26,7 @@ __all__ = [
     "Config",
     "AGUIConfig",
     "AppConfig",
+    "ConversionOptions",
     "StorageConfig",
     "MonitorConfig",
     "LanceDBConfig",

--- a/haiku_rag_slim/haiku/rag/config/models.py
+++ b/haiku_rag_slim/haiku/rag/config/models.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -50,6 +51,23 @@ class ResearchConfig(BaseModel):
     max_concurrency: int = 1
 
 
+class ConversionOptions(BaseModel):
+    """Options for document conversion."""
+
+    # OCR options
+    do_ocr: bool = True
+    force_ocr: bool = False
+    ocr_lang: list[str] = []
+
+    # Table options
+    do_table_structure: bool = True
+    table_mode: Literal["fast", "accurate"] = "accurate"
+    table_cell_matching: bool = True
+
+    # Image options
+    images_scale: float = 2.0
+
+
 class ProcessingConfig(BaseModel):
     chunk_size: int = 256
     context_chunk_radius: int = 0
@@ -60,6 +78,7 @@ class ProcessingConfig(BaseModel):
     chunking_tokenizer: str = "Qwen/Qwen3-Embedding-0.6B"
     chunking_merge_peers: bool = True
     chunking_use_markdown_tables: bool = False
+    conversion_options: ConversionOptions = Field(default_factory=ConversionOptions)
 
 
 class OllamaConfig(BaseModel):

--- a/haiku_rag_slim/haiku/rag/converters/__init__.py
+++ b/haiku_rag_slim/haiku/rag/converters/__init__.py
@@ -21,7 +21,7 @@ def get_converter(config: AppConfig = Config) -> DocumentConverter:
     if config.processing.converter == "docling-local":
         from haiku.rag.converters.docling_local import DoclingLocalConverter
 
-        return DoclingLocalConverter()
+        return DoclingLocalConverter(config)
 
     if config.processing.converter == "docling-serve":
         from haiku.rag.converters.docling_serve import DoclingServeConverter

--- a/haiku_rag_slim/haiku/rag/converters/docling_serve.py
+++ b/haiku_rag_slim/haiku/rag/converters/docling_serve.py
@@ -78,9 +78,27 @@ class DoclingServeConverter(DocumentConverter):
 
         try:
             url = f"{self.base_url}/v1/convert/file"
-            data = {"to_formats": ["json"]}
-            headers = {}
+            opts = self.config.processing.conversion_options
 
+            # Build data dict with conversion options
+            data = {
+                "to_formats": ["json"],
+                # OCR options
+                "do_ocr": opts.do_ocr,
+                "force_ocr": opts.force_ocr,
+                # Table options
+                "do_table_structure": opts.do_table_structure,
+                "table_mode": opts.table_mode,
+                "table_cell_matching": opts.table_cell_matching,
+                # Image options
+                "images_scale": opts.images_scale,
+            }
+
+            # Add OCR language if specified
+            if opts.ocr_lang:
+                data["ocr_lang"] = opts.ocr_lang
+
+            headers = {}
             if self.api_key:
                 headers["X-Api-Key"] = self.api_key
 


### PR DESCRIPTION
- **Conversion Options**: Fine-grained control over document conversion for both local and remote converters
  - New `conversion_options` config section in `ProcessingConfig`
  - OCR settings: `do_ocr`, `force_ocr`, `ocr_lang` for controlling OCR behavior
  - Table extraction: `do_table_structure`, `table_mode` (fast/accurate), `table_cell_matching`
  - Image settings: `images_scale` to control image resolution
  - Options work identically with both `docling-local` and `docling-serve` converters
