### PR TITLE
Accept both single chunks and lists for batch insertion in ChunkRepoitory.create()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 
 ### Changed
 
+- **Chunk Creation**: `ChunkRepository.create()` now accepts both single chunks and lists for batch insertion
+  - Batch insertion reduces LanceDB version creation when adding multiple chunks with custom chunks
+  - Batch embedding generation for improved performance with multiple chunks
 - Updated core dependencies:
 
 ## [0.17.1] - 2025-11-18

--- a/haiku_rag_slim/haiku/rag/client.py
+++ b/haiku_rag_slim/haiku/rag/client.py
@@ -461,11 +461,12 @@ class HaikuRAG:
                 # Update document metadata
                 await self.document_repository.update(existing_doc)
 
-                # Add new chunks
+                # Set document_id and order for all chunks
                 for order, chunk in enumerate(chunks):
                     chunk.document_id = document_id
                     chunk.order = order
-                    await self.chunk_repository.create(chunk)
+                # Batch create all chunks in a single operation
+                await self.chunk_repository.create(chunks)
 
                 return existing_doc
             else:

--- a/haiku_rag_slim/haiku/rag/store/repositories/document.py
+++ b/haiku_rag_slim/haiku/rag/store/repositories/document.py
@@ -213,10 +213,12 @@ class DocumentRepository:
                 assert created_doc.id is not None, (
                     "Document ID should not be None after creation"
                 )
+                # Set document_id and order for all chunks
                 for order, chunk in enumerate(chunks):
                     chunk.document_id = created_doc.id
                     chunk.order = order
-                    await self.chunk_repository.create(chunk)
+                # Batch create all chunks in a single operation
+                await self.chunk_repository.create(chunks)
 
             # Vacuum old versions in background (non-blocking)
             asyncio.create_task(self.store.vacuum())


### PR DESCRIPTION
- **Chunk Creation**: `ChunkRepository.create()` now accepts both single chunks and lists for batch insertion
  - Batch insertion reduces LanceDB version creation when adding multiple chunks with custom chunks
  - Batch embedding generation for improved performance with multiple chunks