### PR TITLE
Set default evaluation  dataset db location, create evaluation script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 ### Added
 
 - **Database Inspector**: New `inspect` CLI command launches interactive TUI for browsing documents and chunks & searching
+- **Evaluations**: Added `evaluations` CLI script for running benchmarks (replaces `python -m evaluations.benchmark`)
+- **Evaluations**: Added `--db` option to override evaluation database path
+  - Default database location moved to haiku.rag data directory:
+    - macOS: `~/Library/Application Support/haiku.rag/evaluations/dbs/`
+    - Linux: `~/.local/share/haiku.rag/evaluations/dbs/`
+    - Windows: `C:/Users/<USER>/AppData/Roaming/haiku.rag/evaluations/dbs/`
+  - Previously stored in `evaluations/data/` within the repository
 - **Evaluations**: Added comprehensive experiment metadata tracking for better reproducibility
   - Records dataset name, test case count, and all model configurations
   - Tracks embedder settings: provider, model, and vector dimensions

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -2,31 +2,37 @@
 
 We use the [repliqa](https://huggingface.co/datasets/ServiceNow/repliqa) dataset for the evaluation of `haiku.rag`.
 
-You can perform your own evaluations with the Typer CLI in
-`evaluations/evaluations/benchmark.py`, for example `python -m evaluations.benchmark repliqa`.
+You can perform your own evaluations with the `evaluations` CLI command:
+
+```bash
+evaluations repliqa
+```
+
 The evaluation flow is orchestrated with
 [`pydantic-evals`](https://github.com/pydantic/pydantic-ai/tree/main/libs/pydantic-evals),
 which we leverage for dataset management, scoring, and report generation.
 
 ## Configuration
 
-The benchmark script accepts a `--config` option to specify a custom `haiku.rag.yaml` configuration file:
+The benchmark script accepts several options:
 
 ```bash
-python -m evaluations.benchmark repliqa --config /path/to/haiku.rag.yaml
+evaluations repliqa --config /path/to/haiku.rag.yaml --db /path/to/custom.lancedb
 ```
 
-If no config file is specified, the script will search for a config file in the standard locations:
-1. `./haiku.rag.yaml` (current directory)
-2. User config directory
-3. Falls back to default configuration
-
-You can also use command-line options:
+**Configuration options:**
+- `--config PATH` - Specify a custom `haiku.rag.yaml` configuration file
+- `--db PATH` - Override the database path (default: `~/.local/share/haiku.rag/evaluations/dbs/{dataset}.lancedb` on Linux, `~/Library/Application Support/haiku.rag/evaluations/dbs/{dataset}.lancedb` on macOS)
 - `--skip-db` - Skip updating the evaluation database
 - `--skip-retrieval` - Skip retrieval benchmark
 - `--skip-qa` - Skip QA benchmark
 - `--limit N` - Limit number of test cases for both retrieval and QA
 - `--name NAME` - Override the evaluation name (defaults to `{dataset}_retrieval_evaluation` or `{dataset}_qa_evaluation`)
+
+If no config file is specified, the script will search for a config file in the standard locations:
+1. `./haiku.rag.yaml` (current directory)
+2. User config directory
+3. Falls back to default configuration
 
 ## RepliQA Retrieval
 

--- a/evaluations/README.md
+++ b/evaluations/README.md
@@ -9,3 +9,33 @@ This package is not published to PyPI and is only used for development and testi
 Contains evaluation scripts for benchmarking RAG performance using datasets like:
 - RepliQA
 - WiX
+
+## Usage
+
+After installing the package, you can run evaluations using the `evaluations` command:
+
+```bash
+# Run evaluations with default settings
+evaluations repliqa
+
+# Use a custom config file
+evaluations repliqa --config /path/to/haiku.rag.yaml
+
+# Override the database path
+evaluations repliqa --db /path/to/custom.lancedb
+
+# Skip database population and run only benchmarks
+evaluations repliqa --skip-db
+
+# Limit the number of test cases
+evaluations repliqa --limit 100
+```
+
+## Database Storage
+
+By default, evaluation databases are stored in the haiku.rag data directory:
+- **Linux**: `~/.local/share/haiku.rag/evaluations/dbs/`
+- **macOS**: `~/Library/Application Support/haiku.rag/evaluations/dbs/`
+- **Windows**: `C:/Users/<USER>/AppData/Roaming/haiku.rag/evaluations/dbs/`
+
+You can override this with the `--db` option.

--- a/evaluations/evaluations/config.py
+++ b/evaluations/evaluations/config.py
@@ -43,6 +43,19 @@ class DatasetSpec:
     retrieval_evaluator: Evaluator | None = None
     document_limit: int | None = None
 
-    @property
-    def db_path(self) -> Path:
-        return Path(__file__).parent / "data" / self.db_filename
+    def db_path(self, override_path: Path | None = None) -> Path:
+        """Get the database path.
+
+        Args:
+            override_path: Optional path to override the default database location.
+
+        Returns:
+            The database path to use.
+        """
+        if override_path is not None:
+            return override_path
+
+        from haiku.rag.utils import get_default_data_dir
+
+        data_dir = get_default_data_dir()
+        return data_dir / "evaluations" / "dbs" / self.db_filename

--- a/evaluations/pyproject.toml
+++ b/evaluations/pyproject.toml
@@ -15,6 +15,9 @@ dependencies = [
     "python-dotenv>=1.2.1",
 ]
 
+[project.scripts]
+evaluations = "evaluations.benchmark:app"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
- **Evaluations**: Added `--db` option to override evaluation database path
  - Default database location moved to haiku.rag data directory:
    - macOS: `~/Library/Application Support/haiku.rag/evaluations/dbs/`
    - Linux: `~/.local/share/haiku.rag/evaluations/dbs/`
    - Windows: `C:/Users/<USER>/AppData/Roaming/haiku.rag/evaluations/dbs/`
  - Previously stored in `evaluations/data/` within the repository
