### PR TITLE
New options for `rebuild` command to control what gets rebuilt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 ## [Unreleased]
 
+### Added
+
+- **Rebuild Modes**: New options for `rebuild` command to control what gets rebuilt
+  - `--embed-only`: Only regenerate embeddings, keeping existing chunks (fastest option when changing embedding model)
+  - `--rechunk`: Re-chunk from existing document content without accessing source files
+  - Default (no flag): Full rebuild with source file re-conversion
+  - Python API: `rebuild_database(mode=RebuildMode.EMBED_ONLY | RECHUNK | FULL)`
+
 ## [0.19.3] - 2025-11-27
 
 ### Changed

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -259,12 +259,26 @@ haiku-rag vacuum
 
 ### Rebuild Database
 
-Rebuild the database by deleting all chunks & embeddings and re-indexing all documents. This is useful
-when want to switch embeddings provider or model:
+Rebuild the database by re-indexing documents. Useful when switching embeddings provider/model or changing chunking settings:
 
 ```bash
+# Full rebuild (default) - re-converts from source files, re-chunks, re-embeds
 haiku-rag rebuild
+
+# Re-chunk from stored content (no source file access)
+haiku-rag rebuild --rechunk
+
+# Only regenerate embeddings (fastest, keeps existing chunks)
+haiku-rag rebuild --embed-only
 ```
+
+**Rebuild modes:**
+
+| Mode | Flag | Use case |
+|------|------|----------|
+| Full | (default) | Changed converter, source files updated |
+| Rechunk | `--rechunk` | Changed chunking strategy or chunk size |
+| Embed only | `--embed-only` | Changed embedding model or vector dimensions |
 
 ### Download Models
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -157,9 +157,26 @@ await client.delete_document(doc.id)
 ### Rebuilding the Database
 
 ```python
+from haiku.rag.client import RebuildMode
+
+# Full rebuild (default) - re-converts from source files, re-chunks, re-embeds
 async for doc_id in client.rebuild_database():
     print(f"Processed document {doc_id}")
+
+# Re-chunk from stored content (no source file access)
+async for doc_id in client.rebuild_database(mode=RebuildMode.RECHUNK):
+    print(f"Processed document {doc_id}")
+
+# Only regenerate embeddings (fastest, keeps existing chunks)
+async for doc_id in client.rebuild_database(mode=RebuildMode.EMBED_ONLY):
+    print(f"Processed document {doc_id}")
 ```
+
+**Rebuild modes:**
+
+- `RebuildMode.FULL` - Re-convert from source files, re-chunk, re-embed (default)
+- `RebuildMode.RECHUNK` - Re-chunk from existing document content, re-embed
+- `RebuildMode.EMBED_ONLY` - Keep existing chunks, only regenerate embeddings
 
 ## Maintenance
 

--- a/haiku_rag_slim/haiku/rag/cli.py
+++ b/haiku_rag_slim/haiku/rag/cli.py
@@ -358,9 +358,32 @@ def rebuild(
         "--db",
         help="Path to the LanceDB database file",
     ),
+    embed_only: bool = typer.Option(
+        False,
+        "--embed-only",
+        help="Only regenerate embeddings, keep existing chunks",
+    ),
+    rechunk: bool = typer.Option(
+        False,
+        "--rechunk",
+        help="Re-chunk from existing content without accessing source files",
+    ),
 ):
+    from haiku.rag.client import RebuildMode
+
+    if embed_only and rechunk:
+        typer.echo("Error: --embed-only and --rechunk are mutually exclusive")
+        raise typer.Exit(1)
+
+    if embed_only:
+        mode = RebuildMode.EMBED_ONLY
+    elif rechunk:
+        mode = RebuildMode.RECHUNK
+    else:
+        mode = RebuildMode.FULL
+
     app = create_app(db)
-    asyncio.run(app.rebuild())
+    asyncio.run(app.rebuild(mode=mode))
 
 
 @cli.command("vacuum", help="Optimize and clean up all tables to reduce disk usage")

--- a/tests/test_rebuild.py
+++ b/tests/test_rebuild.py
@@ -1,86 +1,92 @@
 import pytest
 from datasets import Dataset
 
-from haiku.rag.client import HaikuRAG
-from haiku.rag.store.models.document import Document
+from haiku.rag.client import HaikuRAG, RebuildMode
 
 
 @pytest.mark.asyncio
-async def test_rebuild_database(qa_corpus: Dataset, temp_db_path):
-    """Test rebuild functionality with existing documents."""
+async def test_rebuild_full(qa_corpus: Dataset, temp_db_path):
+    """Test full rebuild: converts, chunks, and embeds all documents."""
     async with HaikuRAG(temp_db_path) as client:
-        created_docs: list[Document] = []
-        for content in qa_corpus["document_extracted"][:3]:
-            doc = await client.create_document(
-                content=content,
-            )
-            created_docs.append(doc)
-
-        documents_before = await client.list_documents()
-        assert len(documents_before) == 3
-
-        chunks_before = []
-        for doc in created_docs:
-            assert doc.id is not None
-            doc_chunks = await client.chunk_repository.get_by_document_id(doc.id)
-            chunks_before.extend(doc_chunks)
-
-        assert len(chunks_before) > 0
-
-        # Perform rebuild
-        processed_doc_ids = []
-        async for doc_id in client.rebuild_database():
-            processed_doc_ids.append(doc_id)
-
-        # Verify all documents were processed
-        expected_doc_ids = [doc.id for doc in created_docs]
-        assert set(processed_doc_ids) == set(expected_doc_ids)
-
-        documents_after = await client.list_documents()
-        assert len(documents_after) == 3
-
-        # Verify chunks were recreated
-        chunks_after = []
-        for doc in documents_after:
-            if doc.id is not None:
-                doc_chunks = await client.chunk_repository.get_by_document_id(doc.id)
-                chunks_after.extend(doc_chunks)
-
-        assert len(chunks_after) > 0
-
-
-@pytest.mark.asyncio
-async def test_rebuild_with_missing_source(qa_corpus: Dataset, temp_db_path):
-    """Test rebuild functionality when document source is missing."""
-    async with HaikuRAG(temp_db_path) as client:
-        # Create document with content
-        content = qa_corpus["document_extracted"][0]
-        doc = await client.create_document(content=content)
-
-        # Manually set a URI that doesn't exist
+        doc = await client.create_document(content=qa_corpus["document_extracted"][0])
         assert doc.id is not None
-        doc_with_uri = await client.document_repository.get_by_id(doc.id)
-        assert doc_with_uri is not None
-        doc_with_uri.uri = "file:///nonexistent/path.txt"
-        await client.document_repository.update(doc_with_uri)
 
-        # Verify chunks exist before rebuild
         chunks_before = await client.chunk_repository.get_by_document_id(doc.id)
         assert len(chunks_before) > 0
+        chunk_ids_before = {c.id for c in chunks_before}
 
-        # Perform rebuild
-        processed_doc_ids = []
-        async for doc_id in client.rebuild_database():
-            processed_doc_ids.append(doc_id)
+        processed_ids = [doc_id async for doc_id in client.rebuild_database()]
 
-        # Document should still be processed (not skipped)
-        assert doc.id in processed_doc_ids
+        assert doc.id in processed_ids
 
-        # Verify document still exists
-        doc_after = await client.document_repository.get_by_id(doc.id)
-        assert doc_after is not None
-        assert doc_after.content == content
-
-        # Verify chunks were recreated from content
         chunks_after = await client.chunk_repository.get_by_document_id(doc.id)
         assert len(chunks_after) > 0
+        chunk_ids_after = {c.id for c in chunks_after}
+
+        # Chunk IDs should change (chunks are recreated)
+        assert chunk_ids_before.isdisjoint(chunk_ids_after)
+
+
+@pytest.mark.asyncio
+async def test_rebuild_embed_only(qa_corpus: Dataset, temp_db_path):
+    """Test embed-only rebuild: keeps chunks, only regenerates embeddings."""
+    async with HaikuRAG(temp_db_path) as client:
+        doc = await client.create_document(content=qa_corpus["document_extracted"][0])
+        assert doc.id is not None
+
+        chunks_before = await client.chunk_repository.get_by_document_id(doc.id)
+        assert len(chunks_before) > 0
+        chunk_ids_before = {c.id for c in chunks_before}
+        chunk_contents_before = {c.id: c.content for c in chunks_before}
+
+        processed_ids = [
+            doc_id
+            async for doc_id in client.rebuild_database(mode=RebuildMode.EMBED_ONLY)
+        ]
+
+        assert doc.id in processed_ids
+
+        chunks_after = await client.chunk_repository.get_by_document_id(doc.id)
+        chunk_ids_after = {c.id for c in chunks_after}
+
+        # Chunk IDs should be preserved (same chunks, just re-embedded)
+        assert chunk_ids_before == chunk_ids_after
+
+        # Content should be identical
+        for chunk in chunks_after:
+            assert chunk.content == chunk_contents_before[chunk.id]
+
+
+@pytest.mark.asyncio
+async def test_rebuild_rechunk(qa_corpus: Dataset, temp_db_path):
+    """Test rechunk rebuild: re-chunks from content without accessing source files."""
+    async with HaikuRAG(temp_db_path) as client:
+        doc = await client.create_document(content=qa_corpus["document_extracted"][0])
+        assert doc.id is not None
+
+        # Set a fake URI to simulate a document that came from a file
+        doc.uri = "file:///nonexistent/path.txt"
+        await client.document_repository.update(doc)
+
+        chunks_before = await client.chunk_repository.get_by_document_id(doc.id)
+        assert len(chunks_before) > 0
+        chunk_ids_before = {c.id for c in chunks_before}
+        content_before = doc.content
+
+        processed_ids = [
+            doc_id async for doc_id in client.rebuild_database(mode=RebuildMode.RECHUNK)
+        ]
+
+        assert doc.id in processed_ids
+
+        # Document content should be unchanged
+        doc_after = await client.document_repository.get_by_id(doc.id)
+        assert doc_after is not None
+        assert doc_after.content == content_before
+
+        chunks_after = await client.chunk_repository.get_by_document_id(doc.id)
+        assert len(chunks_after) > 0
+        chunk_ids_after = {c.id for c in chunks_after}
+
+        # Chunk IDs should change (chunks are recreated)
+        assert chunk_ids_before.isdisjoint(chunk_ids_after)


### PR DESCRIPTION
- **Rebuild Modes**: New options for `rebuild` command to control what gets rebuilt
  - `--embed-only`: Only regenerate embeddings, keeping existing chunks (fastest option when changing embedding model)
  - `--rechunk`: Re-chunk from existing document content without accessing source files
  - Default (no flag): Full rebuild with source file re-conversion
  - Python API: `rebuild_database(mode=RebuildMode.EMBED_ONLY | RECHUNK | FULL)`