### PR TITLE
Use rich rendering for citations in cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
   - `EvaluationResult`: `confidence` → `confidence_score`, `should_continue` → `is_sufficient`, `gaps_identified` → `gaps`, `follow_up_questions` → `new_questions`, added `key_insights`
   - `ResearchReport`: `question` → `title`, `summary` → `executive_summary`, `findings` → `main_findings`, removed `insights_used`/`methodology`, added `limitations`/`recommendations`/`sources_summary`
   - Updated Final Report UI to display new fields (Recommendations, Limitations, Sources)
+- **Citation Formatting**: Citations in CLI now render properly with Rich panels
+  - Content is rendered as markdown with proper code block formatting
+  - No longer truncates or flattens newlines in citation content
 
 ## [0.20.1] - 2025-12-11
 

--- a/haiku_rag_slim/haiku/rag/app.py
+++ b/haiku_rag_slim/haiku/rag/app.py
@@ -29,7 +29,7 @@ from haiku.rag.store.models.document import Document
 
 if TYPE_CHECKING:
     from haiku.rag.store.models import SearchResult
-from haiku.rag.utils import format_bytes, format_citations
+from haiku.rag.utils import format_bytes, format_citations_rich
 
 logger = logging.getLogger(__name__)
 
@@ -370,7 +370,8 @@ class HaikuRAGApp:
                 self.console.print("[bold green]Answer:[/bold green]")
                 self.console.print(Markdown(answer))
                 if cite and citations:
-                    self.console.print(Markdown(format_citations(citations)))
+                    for renderable in format_citations_rich(citations):
+                        self.console.print(renderable)
             except Exception as e:
                 self.console.print(f"[red]Error: {e}[/red]")
 


### PR DESCRIPTION
- **Citation Formatting**: Citations in CLI now render properly with Rich panels
  - Content is rendered as markdown with proper code block formatting
  - No longer truncates or flattens newlines in citation content