### PR TITLE
Fix non-reasoning OpenAI models that do not support reasoning config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 ## [Unreleased]
 
+### Fixed
+
+- **OpenAI Non-Reasoning Models**: Fixed `reasoning_effort` parameter being sent to non-reasoning OpenAI models (gpt-4o, gpt-4o-mini), causing 400 errors. Now correctly detects reasoning models (o1, o3 series) using pydantic-ai's model profile.
+- **Bedrock Non-Reasoning Models**: Fixed same issue for OpenAI models on Bedrock.
+
 ## [0.24.0] - 2026-01-07
 
 ### Added

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -176,6 +176,17 @@ def test_get_model_openai_with_thinking():
     assert isinstance(result, OpenAIChatModel)
 
 
+def test_get_model_openai_non_reasoning_model_ignores_thinking():
+    """Test that non-reasoning OpenAI models don't get reasoning_effort setting."""
+    model_config = ModelConfig(
+        provider="openai", name="gpt-4o-mini", enable_thinking=False
+    )
+    result = get_model(model_config)
+    assert isinstance(result, OpenAIChatModel)
+    # Non-reasoning models should not have reasoning_effort set
+    assert result._settings is None
+
+
 @pytest.mark.skipif(not HAS_ANTHROPIC, reason="Anthropic not installed")
 def test_get_model_anthropic():
     """Test get_model returns AnthropicModel for Anthropic."""


### PR DESCRIPTION

### Fixed

- **OpenAI Non-Reasoning Models**: Fixed `reasoning_effort` parameter being sent to non-reasoning OpenAI models (gpt-4o, gpt-4o-mini), causing 400 errors. Now correctly detects reasoning models (o1, o3 series) using pydantic-ai's model profile.
- **Bedrock Non-Reasoning Models**: Fixed same issue for OpenAI models on Bedrock.

Closes #219 