### PR TITLE
docs: fix documentation discrepancies with codebase

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -34,7 +34,7 @@ haiku-rag list
 
 Filter documents by properties:
 ```bash
-# Filter by URI pattern
+# Filter by URI pattern (--filter or -f)
 haiku-rag list --filter "uri LIKE '%arxiv%'"
 
 # Filter by exact title
@@ -116,10 +116,10 @@ haiku-rag search "machine learning"
 
 With options:
 ```bash
-haiku-rag search "python programming" --limit 10
+haiku-rag search "python programming" --limit 10  # or -l 10
 ```
 
-With filters (filter by document properties):
+With filters (filter by document properties, use `--filter` or `-f`):
 ```bash
 # Filter by URI pattern
 haiku-rag search "neural networks" --filter "uri LIKE '%arxiv%'"
@@ -159,7 +159,7 @@ Flags:
 
 - `--cite`: Include citations showing which documents were used
 - `--deep`: Decompose the question into sub-questions answered in parallel before synthesizing a final answer
-- `--filter`: Restrict searches to documents matching the filter (see [Filtering Search Results](python.md#filtering-search-results))
+- `--filter` / `-f`: Restrict searches to documents matching the filter (see [Filtering Search Results](python.md#filtering-search-results))
 
 ## Chat
 
@@ -182,6 +182,27 @@ The chat interface provides:
 
 See [Applications](apps.md#chat-tui) for keyboard shortcuts and features.
 
+## Inspect
+
+Launch the interactive inspector TUI for browsing documents and chunks:
+
+```bash
+haiku-rag inspect
+haiku-rag inspect --db /path/to/database.lancedb
+```
+
+!!! note
+    Requires the `tui` extra: `pip install haiku.rag-slim[tui]` (included in full `haiku.rag` package)
+
+The inspector provides:
+
+- Browse all documents in the database
+- View document metadata and content
+- Explore individual chunks
+- Search and filter results
+
+See [Applications](apps.md#inspector) for details.
+
 ## Research
 
 Run the multi-step research graph:
@@ -198,7 +219,7 @@ haiku-rag research "What are the key findings?" --filter "uri LIKE '%paper%'"
 
 Flags:
 
-- `--filter`: SQL WHERE clause to filter documents (see [Filtering Search Results](python.md#filtering-search-results))
+- `--filter` / `-f`: SQL WHERE clause to filter documents (see [Filtering Search Results](python.md#filtering-search-results))
 
 Research parameters like `max_iterations`, `confidence_threshold`, and `max_concurrency` are configured in your [configuration file](configuration/index.md) under the `research` section.
 
@@ -233,6 +254,15 @@ View current configuration settings:
 ```bash
 haiku-rag settings
 ```
+
+### Generate Configuration File
+
+Generate a YAML configuration file with defaults:
+```bash
+haiku-rag init-config [output_path]
+```
+
+If no path is specified, creates `haiku.rag.yaml` in the current directory.
 
 ## Database Management
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -37,7 +37,7 @@ The MCP server exposes `haiku.rag` as MCP tools for compatible MCP clients like 
 
 - **`search_documents`** - Search using hybrid search (vector + full-text)
   - `query` (required): Search query
-  - `limit` (optional): Maximum results (default: 5)
+  - `limit` (optional): Maximum results (uses config default if not specified)
 
 ### Question Answering
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -120,7 +120,7 @@ See [Custom Processing Pipelines](custom-pipelines.md) for building pipelines wi
 
 By ID:
 ```python
-doc = await client.get_document_by_id(1)
+doc = await client.get_document_by_id("document-id-string")
 ```
 
 By URI:
@@ -367,6 +367,15 @@ Be concise and helpful."""
 answer, citations = await client.ask(
     "How do I create a blog?",
     system_prompt=custom_prompt
+)
+```
+
+Filter to specific documents:
+
+```python
+answer, citations = await client.ask(
+    "What are the main findings?",
+    filter="uri LIKE '%paper%'"
 )
 ```
 


### PR DESCRIPTION
## Summary
- Fix CLI documentation missing short flags and undocumented commands
- Fix Python API documentation incorrect types and missing parameters
- Fix MCP documentation incorrect default values

## Changes

### CLI Documentation (`docs/cli.md`)
- Add `-f` short flag documentation for `--filter` in list, search, ask, research commands
- Add `-l` short flag documentation for `--limit` in search command
- Add missing `init-config` command documentation
- Add missing `inspect` command documentation

### Python API Documentation (`docs/python.md`)
- Fix `get_document_by_id()` example to use string ID instead of integer
- Add `filter` parameter documentation for `ask()` method

### MCP Documentation (`docs/mcp.md`)
- Correct `search_documents` limit default (uses config default, not hardcoded 5)

## Test plan
- [x] Manual review of documentation changes
- [x] Verified against source code in `haiku_rag_slim/haiku/rag/cli.py`
- [x] Verified against source code in `haiku_rag_slim/haiku/rag/client.py`
- [x] Verified against source code in `haiku_rag_slim/haiku/rag/mcp.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)