### PR TITLE
fix: load .env from current working directory, not source file directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Fixed
 
 - **Test Cassette Organization**: Consolidated all VCR cassettes to `tests/cassettes/`
+- **Environment Loading**: Fixed `.env` file loading to search from current working directory instead of source file directory ([#250](https://github.com/ggozad/haiku.rag/pull/250)) - thanks @tianyicui
 
 ## [0.26.7] - 2026-01-20
 

--- a/app/backend/main.py
+++ b/app/backend/main.py
@@ -2,7 +2,7 @@ import logging
 import os
 from pathlib import Path
 
-from dotenv import load_dotenv
+from dotenv import find_dotenv, load_dotenv
 from pydantic_ai.ui import SSE_CONTENT_TYPE
 from pydantic_ai.ui.ag_ui import AGUIAdapter
 from starlette.applications import Starlette
@@ -23,7 +23,7 @@ from haiku.rag.client import HaikuRAG
 from haiku.rag.config import load_yaml_config
 from haiku.rag.config.models import AppConfig
 
-load_dotenv()
+load_dotenv(find_dotenv(usecwd=True))
 
 # Configure logfire (only sends data if LOGFIRE_TOKEN is present)
 try:

--- a/evaluations/evaluations/benchmark.py
+++ b/evaluations/evaluations/benchmark.py
@@ -5,7 +5,7 @@ from typing import Any, cast
 
 import logfire
 import typer
-from dotenv import load_dotenv
+from dotenv import find_dotenv, load_dotenv
 from pydantic_evals import Case, Dataset as EvalDataset
 from pydantic_evals.evaluators import LLMJudge
 from pydantic_evals.reporting import ReportCaseFailure
@@ -23,7 +23,7 @@ from haiku.rag.logging import configure_cli_logging
 from haiku.rag.agents.qa import get_qa_agent
 from haiku.rag.utils import get_model
 
-load_dotenv()
+load_dotenv(find_dotenv(usecwd=True))
 
 logfire.configure(send_to_logfire="if-token-present", service_name="evals")
 logfire.instrument_pydantic_ai()

--- a/haiku_rag_slim/haiku/rag/cli.py
+++ b/haiku_rag_slim/haiku/rag/cli.py
@@ -14,17 +14,17 @@ from dotenv import find_dotenv, load_dotenv
 # Env loading needs to be before config import; usecwd=True searches from cwd, not this .py file's location
 load_dotenv(find_dotenv(usecwd=True))
 
-from haiku.rag.app import HaikuRAGApp
-from haiku.rag.config import (
+from haiku.rag.app import HaikuRAGApp  # noqa: E402
+from haiku.rag.config import (  # noqa: E402
     AppConfig,
     find_config_file,
     get_config,
     load_yaml_config,
     set_config,
 )
-from haiku.rag.logging import configure_cli_logging
-from haiku.rag.store.exceptions import MigrationRequiredError
-from haiku.rag.utils import is_up_to_date
+from haiku.rag.logging import configure_cli_logging  # noqa: E402
+from haiku.rag.store.exceptions import MigrationRequiredError  # noqa: E402
+from haiku.rag.utils import is_up_to_date  # noqa: E402
 
 _cli = typer.Typer(
     context_settings={"help_option_names": ["-h", "--help"]}, no_args_is_help=True


### PR DESCRIPTION
## Summary
- Move `load_dotenv()` before config imports (config reads env vars at import time)
- Use `find_dotenv(usecwd=True)` to search from the current working directory

## Problem
The previous `load_dotenv()` searched for `.env` starting from the calling file's directory (`haiku/rag/cli.py`), which fails when users run `haiku-rag` from a different directory containing their `.env` file.

## Fix
This fixes the issue where API keys in `.env` files were not being loaded when running `haiku-rag ask` or other commands from a project directory.