### PR TITLE
Evaluations using ask --deep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ### Added
 
+- **Deep Ask Evaluations**: QA benchmarks can now use the research graph for multi-step reasoning
+  - New `--deep` flag on `evaluations run` enables deep ask mode
+  - Uses research graph with `max_iterations=2` and `confidence_threshold=0.0`
+  - Evaluation name automatically suffixed with `_deep` when enabled
+  - Experiment metadata includes `deep_ask` field for tracking
 - **Chat Agent Document Awareness Tools**: Two new tools for browsing and understanding the knowledge base
   - `list_documents` — Returns `DocumentListResponse` with paginated documents (50 per page), page number, total pages, and total count; respects session document filter
   - `summarize_document` — Generate LLM-powered summaries of specific documents

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -60,8 +60,26 @@ evaluations run repliqa --config /path/to/haiku.rag.yaml --db /path/to/custom.la
 - `--skip-qa` - Skip QA benchmark
 - `--limit N` - Limit number of test cases
 - `--name NAME` - Override the evaluation name
+- `--deep` - Use deep QA mode (multi-step reasoning with research graph)
 
 If no config file is specified, the script searches standard locations: `./haiku.rag.yaml`, user config directory, then falls back to defaults.
+
+### Deep QA Mode
+
+The `--deep` flag enables multi-step reasoning using the research graph instead of the simple QA agent:
+
+```bash
+evaluations run repliqa --skip-db --deep
+```
+
+In deep mode:
+
+- Questions are decomposed into sub-questions by a planning agent
+- Each sub-question is answered by searching the knowledge base
+- A synthesis agent combines findings into a comprehensive answer
+- The graph runs for up to 2 iterations with no early exit (confidence threshold disabled)
+
+This matches the behavior of `haiku-rag ask --deep` in the CLI. Deep mode typically produces more thorough answers but requires more LLM calls per question.
 
 ## Methodology
 


### PR DESCRIPTION

- **Deep Ask Evaluations**: QA benchmarks can now use the research graph for multi-step reasoning
  - New `--deep` flag on `evaluations run` enables deep ask mode
  - Uses research graph with `max_iterations=2` and `confidence_threshold=0.0`
  - Evaluation name automatically suffixed with `_deep` when enabled
  - Experiment metadata includes `deep_ask` field for tracking