### PR TITLE
feat: turn off ocr on docling serve chunking 

### DIFF
--- a/haiku_rag_slim/haiku/rag/chunkers/docling_serve.py
+++ b/haiku_rag_slim/haiku/rag/chunkers/docling_serve.py
@@ -64,6 +64,9 @@ class DoclingServeChunker(DocumentChunker):
     def _build_chunking_data(self) -> dict[str, str]:
         """Build form data for chunking request."""
         return {
+            "convert_do_ocr": "false",
+            "convert_force_ocr": "false",
+            "convert_ocr_engine": "tesseract",
             "chunking_max_tokens": str(self.config.processing.chunk_size),
             "chunking_tokenizer": self.config.processing.chunking_tokenizer,
             "chunking_merge_peers": str(


### PR DESCRIPTION
the current invocation of /v1/chunk/** runs into trouble if docling-serve is running in a read-only container. Adding these parameters suppresses that behavior.