### PR TITLE
Pass OCR options from conversion_options to docling-serve chunker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 ## [Unreleased]
 
+### Added
+
+- **docling-serve Chunker OCR Options**: The docling-serve chunker now respects OCR settings from `conversion_options`
+  - Passes `do_ocr`, `force_ocr`, `ocr_engine`, and `ocr_lang` to the chunking API
+  - Allows disabling OCR via config when running docling-serve in read-only containers
+
 ### Fixed
 
 - **CI**: Cache HuggingFace tokenizer to prevent flaky test failures when HuggingFace has transient outages

--- a/docs/configuration/processing.md
+++ b/docs/configuration/processing.md
@@ -230,6 +230,8 @@ providers:
 
 Conversion options work identically for both local and remote processing.
 
+**Note:** When using `chunker: docling-serve`, OCR options (`do_ocr`, `force_ocr`, `ocr_engine`, `ocr_lang`) from `conversion_options` are passed to the chunking API. This is useful when running docling-serve in a read-only container where OCR model downloads fail—set `do_ocr: false` to disable OCR entirely.
+
 ### Chunking Strategies
 
 **Hybrid chunking** (default):

--- a/haiku_rag_slim/haiku/rag/chunkers/docling_serve.py
+++ b/haiku_rag_slim/haiku/rag/chunkers/docling_serve.py
@@ -61,9 +61,13 @@ class DoclingServeChunker(DocumentChunker):
         )
         self.chunker_type = config.processing.chunker_type
 
-    def _build_chunking_data(self) -> dict[str, str]:
+    def _build_chunking_data(self) -> dict[str, str | list[str]]:
         """Build form data for chunking request."""
-        return {
+        opts = self.config.processing.conversion_options
+        data: dict[str, str | list[str]] = {
+            "convert_do_ocr": str(opts.do_ocr).lower(),
+            "convert_force_ocr": str(opts.force_ocr).lower(),
+            "convert_ocr_engine": opts.ocr_engine,
             "chunking_max_tokens": str(self.config.processing.chunk_size),
             "chunking_tokenizer": self.config.processing.chunking_tokenizer,
             "chunking_merge_peers": str(
@@ -73,6 +77,9 @@ class DoclingServeChunker(DocumentChunker):
                 self.config.processing.chunking_use_markdown_tables
             ).lower(),
         }
+        if opts.ocr_lang:
+            data["convert_ocr_lang"] = opts.ocr_lang
+        return data
 
     async def _call_chunk_api(self, document: "DoclingDocument") -> list[dict]:
         """Call docling-serve chunking API and return raw chunk data.


### PR DESCRIPTION

- **docling-serve Chunker OCR Options**: The docling-serve chunker now respects OCR settings from `conversion_options`
  - Passes `do_ocr`, `force_ocr`, `ocr_engine`, and `ocr_lang` to the chunking API
  - Allows disabling OCR via config when running docling-serve in read-only containers

Closes #269 