### PR TITLE
Open database in read-only mode for info and history commands.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### Fixed
 
-- **`info` command**: Open database in read-only mode to prevent write failures on read-only filesystems
+- **`info` and `history` commands**: Open database in read-only mode to prevent write failures on read-only filesystems
 
 ## [0.31.0] - 2026-02-20
 

--- a/haiku_rag_slim/haiku/rag/app.py
+++ b/haiku_rag_slim/haiku/rag/app.py
@@ -205,7 +205,14 @@ class HaikuRAGApp:  # pragma: no cover
             self.console.print("[red]Database path does not exist.[/red]")
             return
 
-        store = Store(self.db_path, config=self.config, skip_validation=True)
+        store = Store(
+            self.db_path,
+            config=self.config,
+            skip_validation=True,
+            read_only=True,
+            skip_migration_check=True,
+            before=self.before,
+        )
 
         tables = ["documents", "chunks", "settings"]
         if table:


### PR DESCRIPTION

### Fixed

- **`info` and `history` commands**: Open database in read-only mode to prevent write failures on read-only filesystems
