### PR TITLE
Build RAG docs database on release

### DIFF
--- a/.github/haiku.rag.yaml
+++ b/.github/haiku.rag.yaml
@@ -1,3 +1,6 @@
+storage:
+  vacuum_retention_seconds: 0
+
 embeddings:
   model:
     provider: ollama

--- a/.github/haiku.rag.yaml
+++ b/.github/haiku.rag.yaml
@@ -1,0 +1,8 @@
+embeddings:
+  model:
+    provider: ollama
+    name: qwen3-embedding:4b
+
+processing:
+  conversion_options:
+    do_ocr: false

--- a/.github/haiku.rag.yaml
+++ b/.github/haiku.rag.yaml
@@ -9,3 +9,11 @@ embeddings:
 processing:
   conversion_options:
     do_ocr: false
+
+ingester:
+  queue:
+    path: ingester.db
+  sources:
+    - type: fs
+      id: docs
+      root: docs

--- a/.github/haiku.rag.yaml
+++ b/.github/haiku.rag.yaml
@@ -13,6 +13,10 @@ processing:
 ingester:
   queue:
     path: ingester.db
+  workers:
+    # One worker: the runner's single CPU-bound Ollama serialises embeds, so
+    # concurrent workers thrash rather than parallelise.
+    worker_count: 1
   sources:
     - type: fs
       id: docs

--- a/.github/workflows/build-rag-db.yml
+++ b/.github/workflows/build-rag-db.yml
@@ -42,6 +42,8 @@ jobs:
           OLLAMA_BASE_URL: ${{ secrets.OLLAMA_BASE_URL }}
           OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
         run: uv run haiku-rag --config ${{ github.workspace }}/.github/haiku.rag.yaml add-src docs/ --db rag.lancedb
+      - name: Vacuum database
+        run: uv run haiku-rag --config ${{ github.workspace }}/.github/haiku.rag.yaml vacuum --db rag.lancedb
       - name: Package RAG database
         run: tar czf haiku-rag-docs.lancedb.tar.gz rag.lancedb/
       - name: Upload to release

--- a/.github/workflows/build-rag-db.yml
+++ b/.github/workflows/build-rag-db.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v4
@@ -18,6 +19,29 @@ jobs:
           python-version-file: "pyproject.toml"
       - name: Install dependencies
         run: uv sync --package haiku.rag-slim --extra docling --no-dev
+      - name: Install Ollama
+        run: curl -fsSL https://ollama.com/install.sh | sh
+      - name: Wait for Ollama
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:11434/api/version >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Ollama did not become ready within 30s" >&2
+          exit 1
+      - name: Cache Ollama models
+        uses: actions/cache@v4
+        with:
+          path: ~/.ollama/models
+          key: ollama-models-qwen3-embedding-4b-v1
+      - name: Pull embedding model
+        run: ollama pull qwen3-embedding:4b
+      - name: Warm embedding model
+        run: |
+          curl -sf -X POST http://localhost:11434/api/embed \
+            -d '{"model":"qwen3-embedding:4b","input":"warmup"}' >/dev/null
       - name: Restore previous RAG database
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -38,9 +62,6 @@ jobs:
             uv run haiku-rag --config ${{ github.workspace }}/.github/haiku.rag.yaml init --db rag.lancedb
           fi
       - name: Build RAG database
-        env:
-          OLLAMA_BASE_URL: ${{ secrets.OLLAMA_BASE_URL }}
-          OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
         run: uv run haiku-rag --config ${{ github.workspace }}/.github/haiku.rag.yaml add-src docs/ --db rag.lancedb
       - name: Vacuum database
         run: uv run haiku-rag --config ${{ github.workspace }}/.github/haiku.rag.yaml vacuum --db rag.lancedb

--- a/.github/workflows/build-rag-db.yml
+++ b/.github/workflows/build-rag-db.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           python-version-file: "pyproject.toml"
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --package haiku.rag-slim --extra docling --no-dev
       - name: Restore previous RAG database
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-rag-db.yml
+++ b/.github/workflows/build-rag-db.yml
@@ -1,0 +1,58 @@
+name: Build RAG database
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: "pyproject.toml"
+      - name: Install dependencies
+        run: uv sync
+      - name: Restore previous RAG database
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LATEST=$(gh release list --limit 10 --json tagName --jq '.[].tagName' | while read -r tag; do
+            if gh release view "$tag" --json assets --jq '.assets[].name' 2>/dev/null | grep -q "haiku-rag-docs.lancedb.tar.gz"; then
+              echo "$tag"
+              break
+            fi
+          done)
+          if [ -n "$LATEST" ]; then
+            gh release download "$LATEST" --pattern "haiku-rag-docs.lancedb.tar.gz"
+            tar xzf haiku-rag-docs.lancedb.tar.gz
+            rm haiku-rag-docs.lancedb.tar.gz
+            echo "Restored database from $LATEST"
+          else
+            echo "No previous database found, starting fresh"
+            uv run haiku-rag --config ${{ github.workspace }}/.github/haiku.rag.yaml init --db rag.lancedb
+          fi
+      - name: Build RAG database
+        env:
+          OLLAMA_BASE_URL: ${{ secrets.OLLAMA_BASE_URL }}
+          OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
+        run: uv run haiku-rag --config ${{ github.workspace }}/.github/haiku.rag.yaml add-src docs/ --db rag.lancedb
+      - name: Package RAG database
+        run: tar czf haiku-rag-docs.lancedb.tar.gz rag.lancedb/
+      - name: Upload to release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload ${{ github.event.release.tag_name }} haiku-rag-docs.lancedb.tar.gz --clobber
+      - name: Upload workflow artifact
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: haiku-rag-docs.lancedb.tar.gz
+          path: haiku-rag-docs.lancedb.tar.gz
+          retention-days: 1

--- a/.github/workflows/build-rag-db.yml
+++ b/.github/workflows/build-rag-db.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v4

--- a/.github/workflows/build-rag-db.yml
+++ b/.github/workflows/build-rag-db.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           python-version-file: "pyproject.toml"
       - name: Install dependencies
-        run: uv sync --package haiku.rag-slim --extra docling --no-dev
+        run: uv sync --package haiku.rag-slim --extra docling --extra ingester --no-dev
       - name: Install Ollama
         run: curl -fsSL https://ollama.com/install.sh | sh
       - name: Wait for Ollama
@@ -47,35 +47,34 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           LATEST=$(gh release list --limit 10 --json tagName --jq '.[].tagName' | while read -r tag; do
-            if gh release view "$tag" --json assets --jq '.assets[].name' 2>/dev/null | grep -q "haiku-rag-docs.lancedb.tar.gz"; then
+            if gh release view "$tag" --json assets --jq '.assets[].name' 2>/dev/null | grep -q "haiku-rag-docs.tar.gz"; then
               echo "$tag"
               break
             fi
           done)
           if [ -n "$LATEST" ]; then
-            gh release download "$LATEST" --pattern "haiku-rag-docs.lancedb.tar.gz"
-            tar xzf haiku-rag-docs.lancedb.tar.gz
-            rm haiku-rag-docs.lancedb.tar.gz
+            gh release download "$LATEST" --pattern "haiku-rag-docs.tar.gz"
+            tar xzf haiku-rag-docs.tar.gz
+            rm haiku-rag-docs.tar.gz
             echo "Restored database from $LATEST"
           else
             echo "No previous database found, starting fresh"
-            uv run haiku-rag --config ${{ github.workspace }}/.github/haiku.rag.yaml init --db rag.lancedb
           fi
       - name: Build RAG database
-        run: uv run haiku-rag --config ${{ github.workspace }}/.github/haiku.rag.yaml add-src docs/ --db rag.lancedb
+        run: uv run haiku-ingester --config ${{ github.workspace }}/.github/haiku.rag.yaml run-batch --db rag.lancedb
       - name: Vacuum database
         run: uv run haiku-rag --config ${{ github.workspace }}/.github/haiku.rag.yaml vacuum --db rag.lancedb
       - name: Package RAG database
-        run: tar czf haiku-rag-docs.lancedb.tar.gz rag.lancedb/
+        run: tar czf haiku-rag-docs.tar.gz rag.lancedb/ ingester.db*
       - name: Upload to release
         if: github.event_name == 'release'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ github.event.release.tag_name }} haiku-rag-docs.lancedb.tar.gz --clobber
+        run: gh release upload ${{ github.event.release.tag_name }} haiku-rag-docs.tar.gz --clobber
       - name: Upload workflow artifact
         if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
-          name: haiku-rag-docs.lancedb.tar.gz
-          path: haiku-rag-docs.lancedb.tar.gz
+          name: haiku-rag-docs.tar.gz
+          path: haiku-rag-docs.tar.gz
           retention-days: 1


### PR DESCRIPTION
- Adds a GitHub Actions workflow that builds a LanceDB database from docs/ on each release
- Uses `haiku-ingester run-batch`: ingests new and changed docs, and deletes docs that were removed from the tree
- Restores the previous release's database and queue, so only changed docs are re-processed and deletions are detected
- Uploads the database and queue as a release artifact (`haiku-rag-docs.tar.gz`)