### PR TITLE
Bd chunk fetch

### DIFF
--- a/app/haiku.rag.yaml.example
+++ b/app/haiku.rag.yaml.example
@@ -34,6 +34,7 @@ embeddings:
 search:
   limit: 5
   context_radius: 0
+  # context_expansion_mode: auto  # auto, chunks, or disabled
 
 # Provider settings
 providers:

--- a/docs/apps.md
+++ b/docs/apps.md
@@ -182,8 +182,9 @@ Search uses hybrid (vector + full-text) search across all chunks.
 
 Press `c` while viewing a chunk to see the expanded context that would be provided to the QA agent:
 
-- Type-aware expansion: tables, code blocks, and lists expand to their complete structures
+- Type-aware expansion: tables, code blocks, and lists expand to their complete structures (when `search.context_expansion_mode` is `auto`)
 - Text content expands based on `search.context_radius` setting
+- Set `search.context_expansion_mode` to `chunks` for faster expansion on large corpora, or `disabled` to skip expansion
 - Includes metadata like source document, content type, and relevance score
 
 ### Visual Grounding

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -100,6 +100,7 @@ research:
 search:
   limit: 10                    # Default number of results to return
   context_radius: 0            # DocItems before/after to include for text content
+  context_expansion_mode: auto # auto, chunks, or disabled
   max_context_items: 10        # Maximum items in expanded context
   max_context_chars: 10000     # Maximum characters in expanded context
   vector_index_metric: cosine  # cosine, l2, or dot

--- a/docs/configuration/qa-research.md
+++ b/docs/configuration/qa-research.md
@@ -8,16 +8,21 @@ Configure search behavior and context expansion:
 search:
   limit: 10                    # Default number of results to return
   context_radius: 0            # DocItems before/after to include for text content
+  context_expansion_mode: auto # auto, chunks, or disabled
   max_context_items: 10        # Maximum items in expanded context
   max_context_chars: 10000     # Maximum characters in expanded context
 ```
 
 - **limit**: Default number of search results to return when no limit is specified. Used by CLI, MCP server, QA, and research workflows. Default: 10
 - **context_radius**: For text content (paragraphs), includes N DocItems before and after. Set to 0 to disable expansion (default).
+- **context_expansion_mode**: Controls which expansion strategy is used. Default: `auto`.
+    - `auto`: Prefer DoclingDocument-based expansion when doc_item_refs exist (structure-aware), fall back to chunk-based expansion.
+    - `chunks`: Always use chunk-based expansion. Skips DoclingDocument decompression, which can be significantly faster for large corpora.
+    - `disabled`: No expansion at all — return search results as-is.
 - **max_context_items**: Limits how many document items (paragraphs, list items, etc.) can be included in expanded context. Default: 10.
 - **max_context_chars**: Hard limit on total characters in expanded content. Default: 10000.
 
-Structural content (tables, code blocks, lists) uses type-aware expansion that automatically includes the complete structure regardless of how it was chunked.
+Structural content (tables, code blocks, lists) uses type-aware expansion that automatically includes the complete structure regardless of how it was chunked. This applies when `context_expansion_mode` is `auto`.
 
 !!! note "Reranking behavior"
     When a reranker is configured, search automatically retrieves 10x the requested limit, then reranks to return the final count. This improves result quality without requiring you to adjust `limit`.

--- a/docs/python.md
+++ b/docs/python.md
@@ -376,10 +376,11 @@ for result in expanded_results:
 Context expansion uses your configuration settings:
 
 - **search.context_radius**: For text content (paragraphs), includes N DocItems before and after
+- **search.context_expansion_mode**: Controls the expansion strategy — `auto` (default, structure-aware with fallback), `chunks` (chunk-based only, faster for large corpora), or `disabled` (no expansion)
 - **search.max_context_items**: Limits how many document items can be included
 - **search.max_context_chars**: Hard limit on total characters
 
-**Type-aware expansion**: Structural content (tables, code blocks, lists) automatically expands to include the complete structure, regardless of how it was split during chunking.
+**Type-aware expansion**: Structural content (tables, code blocks, lists) automatically expands to include the complete structure, regardless of how it was split during chunking. This applies when `context_expansion_mode` is `auto`.
 
 **Smart Merging**: When expanded chunks overlap or are adjacent within the same document, they are automatically merged into single chunks with continuous content. This eliminates duplication and provides coherent text blocks. The merged chunk uses the highest relevance score from the original chunks.
 

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -28,6 +28,8 @@ When configured, a cross-encoder reranker re-scores 10x the requested candidates
 
 `context_radius` expands text chunks with neighboring document items. Structural content (tables, code blocks, lists) expands automatically to include the complete structure. This setting matters most with small `chunk_size` values, where individual chunks may lack sufficient context. `max_context_items` and `max_context_chars` cap expansion to prevent context bloat.
 
+`context_expansion_mode` controls which expansion strategy is used. The default `auto` uses DoclingDocument-based expansion (structure-aware) when available, falling back to chunk-based expansion. Set to `chunks` to skip DoclingDocument decompression for faster performance on large corpora, or `disabled` to skip expansion entirely.
+
 ## Tuning Generation
 
 Model and temperature selection affect answer quality directly — see [Providers](configuration/providers.md#model-settings) for options.

--- a/haiku_rag_slim/haiku/rag/agents/qa/agent.py
+++ b/haiku_rag_slim/haiku/rag/agents/qa/agent.py
@@ -58,7 +58,6 @@ class QuestionAnswerAgent:
             tool_name="search",
             on_results=accumulated_results.extend,
             max_searches=max_searches,
-            expand_context=False,
         )
 
         # Agent created per-call: toolset varies with filter, and Agent

--- a/haiku_rag_slim/haiku/rag/agents/qa/agent.py
+++ b/haiku_rag_slim/haiku/rag/agents/qa/agent.py
@@ -58,6 +58,7 @@ class QuestionAnswerAgent:
             tool_name="search",
             on_results=accumulated_results.extend,
             max_searches=max_searches,
+            expand_context=False,
         )
 
         # Agent created per-call: toolset varies with filter, and Agent
@@ -81,9 +82,7 @@ class QuestionAnswerAgent:
         t0 = time.perf_counter()
         result = await agent.run(question, deps=deps)
         agent_duration = time.perf_counter() - t0
-        logger.info(
-            "qa.agent_run took %.3fs", agent_duration
-        )
+        logger.info("qa.agent_run took %.3fs", agent_duration)
 
         t0 = time.perf_counter()
         output = result.output
@@ -93,7 +92,5 @@ class QuestionAnswerAgent:
             len(citations),
             time.perf_counter() - t0,
         )
-        logger.info(
-            "qa.answer completed total=%.3fs", agent_duration
-        )
+        logger.info("qa.answer completed total=%.3fs", agent_duration)
         return output.answer, citations

--- a/haiku_rag_slim/haiku/rag/agents/qa/agent.py
+++ b/haiku_rag_slim/haiku/rag/agents/qa/agent.py
@@ -1,3 +1,5 @@
+import logging
+import time
 from dataclasses import dataclass
 
 from pydantic_ai import Agent
@@ -14,6 +16,8 @@ from haiku.rag.config.models import AppConfig, ModelConfig
 from haiku.rag.store.models import SearchResult
 from haiku.rag.tools.search import create_search_toolset
 from haiku.rag.utils import get_model
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -73,8 +77,23 @@ class QuestionAnswerAgent:
         )
 
         deps = _QARunDeps(client=self._client)
-        result = await agent.run(question, deps=deps)
-        output = result.output
 
+        t0 = time.perf_counter()
+        result = await agent.run(question, deps=deps)
+        agent_duration = time.perf_counter() - t0
+        logger.info(
+            "qa.agent_run took %.3fs", agent_duration
+        )
+
+        t0 = time.perf_counter()
+        output = result.output
         citations = resolve_citations(output.cited_chunks, accumulated_results)
+        logger.info(
+            "qa.resolve_citations count=%d took %.3fs",
+            len(citations),
+            time.perf_counter() - t0,
+        )
+        logger.info(
+            "qa.answer completed total=%.3fs", agent_duration
+        )
         return output.answer, citations

--- a/haiku_rag_slim/haiku/rag/agents/qa/agent.py
+++ b/haiku_rag_slim/haiku/rag/agents/qa/agent.py
@@ -18,6 +18,7 @@ from haiku.rag.tools.search import create_search_toolset
 from haiku.rag.utils import get_model
 
 logger = logging.getLogger(__name__)
+perf_logger = logging.getLogger("haiku.rag.perf")
 
 
 @dataclass
@@ -81,15 +82,15 @@ class QuestionAnswerAgent:
         t0 = time.perf_counter()
         result = await agent.run(question, deps=deps)
         agent_duration = time.perf_counter() - t0
-        logger.info("qa.agent_run took %.3fs", agent_duration)
+        perf_logger.debug("qa.agent_run took %.3fs", agent_duration)
 
         t0 = time.perf_counter()
         output = result.output
         citations = resolve_citations(output.cited_chunks, accumulated_results)
-        logger.info(
+        perf_logger.debug(
             "qa.resolve_citations count=%d took %.3fs",
             len(citations),
             time.perf_counter() - t0,
         )
-        logger.info("qa.answer completed total=%.3fs", agent_duration)
+        perf_logger.debug("qa.answer completed total=%.3fs", agent_duration)
         return output.answer, citations

--- a/haiku_rag_slim/haiku/rag/client.py
+++ b/haiku_rag_slim/haiku/rag/client.py
@@ -1109,9 +1109,7 @@ class HaikuRAG:
             # Step 3: Reranking
             t0 = time.perf_counter()
             chunks = [chunk for chunk, _ in raw_results]
-            chunk_results = await reranker.rerank(
-                query, chunks, top_n=limit
-            )
+            chunk_results = await reranker.rerank(query, chunks, top_n=limit)
             logger.info(
                 "search.rerank candidates=%d top_n=%d took %.3fs",
                 len(chunks),
@@ -1122,8 +1120,7 @@ class HaikuRAG:
         # Step 4: Build SearchResult objects
         t0 = time.perf_counter()
         results = [
-            SearchResult.from_chunk(chunk, score)
-            for chunk, score in chunk_results
+            SearchResult.from_chunk(chunk, score) for chunk, score in chunk_results
         ]
         logger.info(
             "search.build_results count=%d took %.3fs",
@@ -1209,9 +1206,7 @@ class HaikuRAG:
             if has_refs:
                 # Only fetch docling data (skip content blob)
                 t0 = time.perf_counter()
-                doc = await self.document_repository.get_docling_data(
-                    doc_id
-                )
+                doc = await self.document_repository.get_docling_data(doc_id)
                 logger.info(
                     "expand.fetch_docling_data doc=%s took %.3fs",
                     doc_id[:8],
@@ -1221,7 +1216,7 @@ class HaikuRAG:
                     t0 = time.perf_counter()
                     docling_doc = doc.get_docling_document()
                     logger.info(
-                        "expand.decompress_docling doc=%s took %.3fs",
+                        "expand.get_docling_document doc=%s took %.3fs",
                         doc_id[:8],
                         time.perf_counter() - t0,
                     )
@@ -1237,7 +1232,7 @@ class HaikuRAG:
                     max_chars,
                 )
                 logger.info(
-                    "expand.docling doc=%s results=%d->%d took %.3fs",
+                    "expand._expand_with_docling doc=%s results=%d->%d took %.3fs",
                     doc_id[:8],
                     len(doc_results),
                     len(expanded),
@@ -1252,7 +1247,7 @@ class HaikuRAG:
                         doc_id, doc_results, radius
                     )
                     logger.info(
-                        "expand.chunks doc=%s results=%d->%d took %.3fs",
+                        "expand._expand_with_chunks doc=%s results=%d->%d took %.3fs",
                         doc_id[:8],
                         len(doc_results),
                         len(expanded),
@@ -1531,9 +1526,7 @@ class HaikuRAG:
         if not chunk_ids:
             return results
 
-        id_to_order = await self.chunk_repository.get_orders_by_ids(
-            chunk_ids
-        )
+        id_to_order = await self.chunk_repository.get_orders_by_ids(chunk_ids)
         if not id_to_order:
             return results
 
@@ -1543,10 +1536,8 @@ class HaikuRAG:
         range_max = max(orders) + radius
 
         # Fetch only chunks in the needed range
-        chunks_in_doc = (
-            await self.chunk_repository.get_by_document_id_order_range(
-                doc_id, range_min, range_max
-            )
+        chunks_in_doc = await self.chunk_repository.get_by_document_id_order_range(
+            doc_id, range_min, range_max
         )
         if not chunks_in_doc:
             return results

--- a/haiku_rag_slim/haiku/rag/client.py
+++ b/haiku_rag_slim/haiku/rag/client.py
@@ -103,13 +103,6 @@ class HaikuRAG:
         """Whether the client is in read-only mode."""
         return self.store.is_read_only
 
-    def _compress_docling(self, json_str: str) -> bytes:
-        """Compress a docling JSON string, respecting config."""
-        return compress_json(
-            json_str,
-            enabled=self._config.storage.compress_docling,
-        )
-
     async def __aenter__(self):
         """Async context manager entry."""
         return self
@@ -502,7 +495,7 @@ class HaikuRAG:
             uri=uri,
             title=title,
             metadata=metadata or {},
-            docling_document=self._compress_docling(docling_document.model_dump_json()),
+            docling_document=compress_json(docling_document.model_dump_json()),
             docling_version=docling_document.version,
         )
 
@@ -542,7 +535,7 @@ class HaikuRAG:
             uri=uri,
             title=title,
             metadata=metadata or {},
-            docling_document=self._compress_docling(docling_document.model_dump_json()),
+            docling_document=compress_json(docling_document.model_dump_json()),
             docling_version=docling_document.version,
         )
 
@@ -679,7 +672,7 @@ class HaikuRAG:
             # Update existing document and rechunk
             existing_doc.content = stored_content
             existing_doc.metadata = metadata
-            existing_doc.docling_document = self._compress_docling(
+            existing_doc.docling_document = compress_json(
                 docling_document.model_dump_json()
             )
             existing_doc.docling_version = docling_document.version
@@ -701,7 +694,7 @@ class HaikuRAG:
                 uri=uri,
                 title=title,
                 metadata=metadata,
-                docling_document=self._compress_docling(docling_document.model_dump_json()),
+                docling_document=compress_json(docling_document.model_dump_json()),
                 docling_version=docling_document.version,
             )
             return await self._store_document_with_chunks(document, embedded_chunks)
@@ -796,7 +789,7 @@ class HaikuRAG:
                 # Update existing document and rechunk
                 existing_doc.content = stored_content
                 existing_doc.metadata = metadata
-                existing_doc.docling_document = self._compress_docling(
+                existing_doc.docling_document = compress_json(
                     docling_document.model_dump_json()
                 )
                 existing_doc.docling_version = docling_document.version
@@ -818,7 +811,7 @@ class HaikuRAG:
                     uri=url,
                     title=title,
                     metadata=metadata,
-                    docling_document=self._compress_docling(docling_document.model_dump_json()),
+                    docling_document=compress_json(docling_document.model_dump_json()),
                     docling_version=docling_document.version,
                 )
                 return await self._store_document_with_chunks(document, embedded_chunks)
@@ -978,7 +971,7 @@ class HaikuRAG:
             # Store docling data if provided
             if docling_document is not None:
                 existing_doc.content = docling_document.export_to_markdown()
-                existing_doc.docling_document = self._compress_docling(
+                existing_doc.docling_document = compress_json(
                     docling_document.model_dump_json()
                 )
                 existing_doc.docling_version = docling_document.version
@@ -990,7 +983,7 @@ class HaikuRAG:
         # DoclingDocument provided without chunks - chunk and embed using primitives
         if docling_document is not None:
             existing_doc.content = docling_document.export_to_markdown()
-            existing_doc.docling_document = self._compress_docling(
+            existing_doc.docling_document = compress_json(
                 docling_document.model_dump_json()
             )
             existing_doc.docling_version = docling_document.version
@@ -1005,7 +998,7 @@ class HaikuRAG:
         assert content is not None
         existing_doc.content = content
         converted_docling = await self.convert(existing_doc.content)
-        existing_doc.docling_document = self._compress_docling(
+        existing_doc.docling_document = compress_json(
             converted_docling.model_dump_json()
         )
         existing_doc.docling_version = converted_docling.version
@@ -1182,9 +1175,14 @@ class HaikuRAG:
 
         expand_start = time.perf_counter()
 
+        mode = self._config.search.context_expansion_mode
         radius = self._config.search.context_radius
         max_items = self._config.search.max_context_items
         max_chars = self._config.search.max_context_chars
+
+        if mode == "disabled":
+            logger.info("expand.disabled, skipping")
+            return search_results
 
         # Group by document_id for efficient processing
         document_groups: dict[str | None, list[SearchResult]] = {}
@@ -1195,9 +1193,10 @@ class HaikuRAG:
             document_groups[doc_id].append(result)
 
         logger.info(
-            "expand.groups docs=%d results=%d",
+            "expand.groups docs=%d results=%d mode=%s",
             len(document_groups),
             len(search_results),
+            mode,
         )
 
         expanded_results = []
@@ -1210,7 +1209,7 @@ class HaikuRAG:
             has_refs = any(r.doc_item_refs for r in doc_results)
             docling_doc = None
 
-            if has_refs:
+            if mode == "auto" and has_refs:
                 # Only fetch docling data (skip content blob)
                 t0 = time.perf_counter()
                 doc = await self.document_repository.get_docling_data(doc_id)
@@ -1973,7 +1972,7 @@ class HaikuRAG:
             embedded_chunks = await embed_chunks(chunks, self._config)
 
             # Update document fields
-            doc.docling_document = self._compress_docling(docling_document.model_dump_json())
+            doc.docling_document = compress_json(docling_document.model_dump_json())
             doc.docling_version = docling_document.version
 
             # Prepare chunks with document_id and order
@@ -2052,7 +2051,7 @@ class HaikuRAG:
             chunks = await self.chunk(docling_document)
             embedded_chunks = await embed_chunks(chunks, self._config)
 
-            doc.docling_document = self._compress_docling(docling_document.model_dump_json())
+            doc.docling_document = compress_json(docling_document.model_dump_json())
             doc.docling_version = docling_document.version
 
             # Prepare chunks with document_id and order

--- a/haiku_rag_slim/haiku/rag/client.py
+++ b/haiku_rag_slim/haiku/rag/client.py
@@ -103,6 +103,13 @@ class HaikuRAG:
         """Whether the client is in read-only mode."""
         return self.store.is_read_only
 
+    def _compress_docling(self, json_str: str) -> bytes:
+        """Compress a docling JSON string, respecting config."""
+        return compress_json(
+            json_str,
+            enabled=self._config.storage.compress_docling,
+        )
+
     async def __aenter__(self):
         """Async context manager entry."""
         return self
@@ -495,7 +502,7 @@ class HaikuRAG:
             uri=uri,
             title=title,
             metadata=metadata or {},
-            docling_document=compress_json(docling_document.model_dump_json()),
+            docling_document=self._compress_docling(docling_document.model_dump_json()),
             docling_version=docling_document.version,
         )
 
@@ -535,7 +542,7 @@ class HaikuRAG:
             uri=uri,
             title=title,
             metadata=metadata or {},
-            docling_document=compress_json(docling_document.model_dump_json()),
+            docling_document=self._compress_docling(docling_document.model_dump_json()),
             docling_version=docling_document.version,
         )
 
@@ -672,7 +679,7 @@ class HaikuRAG:
             # Update existing document and rechunk
             existing_doc.content = stored_content
             existing_doc.metadata = metadata
-            existing_doc.docling_document = compress_json(
+            existing_doc.docling_document = self._compress_docling(
                 docling_document.model_dump_json()
             )
             existing_doc.docling_version = docling_document.version
@@ -694,7 +701,7 @@ class HaikuRAG:
                 uri=uri,
                 title=title,
                 metadata=metadata,
-                docling_document=compress_json(docling_document.model_dump_json()),
+                docling_document=self._compress_docling(docling_document.model_dump_json()),
                 docling_version=docling_document.version,
             )
             return await self._store_document_with_chunks(document, embedded_chunks)
@@ -789,7 +796,7 @@ class HaikuRAG:
                 # Update existing document and rechunk
                 existing_doc.content = stored_content
                 existing_doc.metadata = metadata
-                existing_doc.docling_document = compress_json(
+                existing_doc.docling_document = self._compress_docling(
                     docling_document.model_dump_json()
                 )
                 existing_doc.docling_version = docling_document.version
@@ -811,7 +818,7 @@ class HaikuRAG:
                     uri=url,
                     title=title,
                     metadata=metadata,
-                    docling_document=compress_json(docling_document.model_dump_json()),
+                    docling_document=self._compress_docling(docling_document.model_dump_json()),
                     docling_version=docling_document.version,
                 )
                 return await self._store_document_with_chunks(document, embedded_chunks)
@@ -971,7 +978,7 @@ class HaikuRAG:
             # Store docling data if provided
             if docling_document is not None:
                 existing_doc.content = docling_document.export_to_markdown()
-                existing_doc.docling_document = compress_json(
+                existing_doc.docling_document = self._compress_docling(
                     docling_document.model_dump_json()
                 )
                 existing_doc.docling_version = docling_document.version
@@ -983,7 +990,7 @@ class HaikuRAG:
         # DoclingDocument provided without chunks - chunk and embed using primitives
         if docling_document is not None:
             existing_doc.content = docling_document.export_to_markdown()
-            existing_doc.docling_document = compress_json(
+            existing_doc.docling_document = self._compress_docling(
                 docling_document.model_dump_json()
             )
             existing_doc.docling_version = docling_document.version
@@ -998,7 +1005,7 @@ class HaikuRAG:
         assert content is not None
         existing_doc.content = content
         converted_docling = await self.convert(existing_doc.content)
-        existing_doc.docling_document = compress_json(
+        existing_doc.docling_document = self._compress_docling(
             converted_docling.model_dump_json()
         )
         existing_doc.docling_version = converted_docling.version
@@ -1966,7 +1973,7 @@ class HaikuRAG:
             embedded_chunks = await embed_chunks(chunks, self._config)
 
             # Update document fields
-            doc.docling_document = compress_json(docling_document.model_dump_json())
+            doc.docling_document = self._compress_docling(docling_document.model_dump_json())
             doc.docling_version = docling_document.version
 
             # Prepare chunks with document_id and order
@@ -2045,7 +2052,7 @@ class HaikuRAG:
             chunks = await self.chunk(docling_document)
             embedded_chunks = await embed_chunks(chunks, self._config)
 
-            doc.docling_document = compress_json(docling_document.model_dump_json())
+            doc.docling_document = self._compress_docling(docling_document.model_dump_json())
             doc.docling_version = docling_document.version
 
             # Prepare chunks with document_id and order

--- a/haiku_rag_slim/haiku/rag/client.py
+++ b/haiku_rag_slim/haiku/rag/client.py
@@ -894,13 +894,21 @@ class HaikuRAG:
             return doc
 
         safe_input = _escape_sql_string(id_or_title)
-        docs = await self.list_documents(filter=f"title = '{safe_input}'")
-        if docs and docs[0].id:
-            return await self.get_document_by_id(docs[0].id)
+        docs = await self.list_documents(
+            filter=f"title = '{safe_input}'",
+            include_content=True,
+            limit=1,
+        )
+        if docs:
+            return docs[0]
 
-        docs = await self.list_documents(filter=f"uri = '{safe_input}'")
-        if docs and docs[0].id:
-            return await self.get_document_by_id(docs[0].id)
+        docs = await self.list_documents(
+            filter=f"uri = '{safe_input}'",
+            include_content=True,
+            limit=1,
+        )
+        if docs:
+            return docs[0]
 
         return None
 
@@ -1055,24 +1063,95 @@ class HaikuRAG:
         Returns:
             List of SearchResult objects ordered by relevance.
         """
+        import time
+
+        import logfire
+
+        search_start = time.perf_counter()
+
         if limit is None:
             limit = self._config.search.limit
 
+        # Step 1: Get reranker
+        t0 = time.perf_counter()
         reranker = get_reranker(config=self._config)
+        logger.debug(
+            "search reranker_init took %.3fs",
+            time.perf_counter() - t0,
+        )
 
+        # Step 2: Chunk search
+        t0 = time.perf_counter()
         if reranker is None:
             chunk_results = await self.chunk_repository.search(
                 query, limit, search_type, filter
+            )
+            logger.debug(
+                "search chunk_search type=%s limit=%d results=%d took %.3fs",
+                search_type,
+                limit,
+                len(chunk_results),
+                time.perf_counter() - t0,
             )
         else:
             search_limit = limit * 10
             raw_results = await self.chunk_repository.search(
                 query, search_limit, search_type, filter
             )
-            chunks = [chunk for chunk, _ in raw_results]
-            chunk_results = await reranker.rerank(query, chunks, top_n=limit)
+            logger.debug(
+                "search chunk_search type=%s limit=%d results=%d took %.3fs",
+                search_type,
+                search_limit,
+                len(raw_results),
+                time.perf_counter() - t0,
+            )
 
-        return [SearchResult.from_chunk(chunk, score) for chunk, score in chunk_results]
+            # Step 3: Reranking
+            t0 = time.perf_counter()
+            chunks = [chunk for chunk, _ in raw_results]
+            chunk_results = await reranker.rerank(
+                query, chunks, top_n=limit
+            )
+            logger.debug(
+                "search rerank candidates=%d top_n=%d took %.3fs",
+                len(chunks),
+                limit,
+                time.perf_counter() - t0,
+            )
+
+        # Step 4: Build SearchResult objects
+        t0 = time.perf_counter()
+        results = [
+            SearchResult.from_chunk(chunk, score)
+            for chunk, score in chunk_results
+        ]
+        logger.debug(
+            "search build_results count=%d took %.3fs",
+            len(results),
+            time.perf_counter() - t0,
+        )
+
+        duration_s = time.perf_counter() - search_start
+        logger.info(
+            "search completed query=%r type=%s results=%d duration=%.3fs",
+            query[:80],
+            search_type,
+            len(results),
+            duration_s,
+        )
+        logfire.metric_histogram(
+            "search.duration",
+            unit="s",
+        ).record(
+            duration_s,
+            attributes={
+                "search_type": search_type,
+                "result_count": len(results),
+                "reranked": reranker is not None,
+            },
+        )
+
+        return results
 
     async def expand_context(
         self,
@@ -1114,19 +1193,18 @@ class HaikuRAG:
                 expanded_results.extend(doc_results)
                 continue
 
-            # Fetch the document to get DoclingDocument
-            doc = await self.get_document_by_id(doc_id)
-            if doc is None:
-                expanded_results.extend(doc_results)
-                continue
-
-            docling_doc = doc.get_docling_document()
-
-            # Check if we can use DoclingDocument-based expansion
-            has_docling = docling_doc is not None
             has_refs = any(r.doc_item_refs for r in doc_results)
+            docling_doc = None
 
-            if has_docling and has_refs:
+            if has_refs:
+                # Only fetch docling data (skip content blob)
+                doc = await self.document_repository.get_docling_data(
+                    doc_id
+                )
+                if doc is not None:
+                    docling_doc = doc.get_docling_document()
+
+            if docling_doc is not None and has_refs:
                 # Use DoclingDocument-based expansion
                 expanded = await self._expand_with_docling(
                     doc_results,
@@ -1320,12 +1398,14 @@ class HaikuRAG:
         Structural content (tables, code, lists) expands to complete structures.
         Text content uses radius-based expansion.
         """
-        all_items = list(docling_doc.iterate_items())
-        ref_to_index = {
-            getattr(item, "self_ref", None): i
-            for i, (item, _) in enumerate(all_items)
-            if getattr(item, "self_ref", None)
-        }
+        # Single-pass: build items list and ref index together
+        all_items = []
+        ref_to_index = {}
+        for i, item_tuple in enumerate(docling_doc.iterate_items()):
+            all_items.append(item_tuple)
+            ref = getattr(item_tuple[0], "self_ref", None)
+            if ref:
+                ref_to_index[ref] = i
 
         # Compute expanded ranges
         ranges: list[tuple[int, int, SearchResult]] = []
@@ -1403,25 +1483,46 @@ class HaikuRAG:
         radius: int,
     ) -> list[SearchResult]:
         """Expand results using chunk-based adjacency."""
-        all_chunks = await self.chunk_repository.get_by_document_id(doc_id)
-        if not all_chunks:
+        # Get orders for result chunks (lightweight query)
+        chunk_ids = [r.chunk_id for r in results if r.chunk_id]
+        if not chunk_ids:
             return results
 
-        content_to_chunk = {c.content: c for c in all_chunks}
-        chunk_by_order = {c.order: c for c in all_chunks}
-        min_order, max_order = min(chunk_by_order.keys()), max(chunk_by_order.keys())
+        id_to_order = await self.chunk_repository.get_orders_by_ids(
+            chunk_ids
+        )
+        if not id_to_order:
+            return results
+
+        # Compute the order range we actually need
+        orders = list(id_to_order.values())
+        range_min = min(orders) - radius
+        range_max = max(orders) + radius
+
+        # Fetch only chunks in the needed range
+        chunks_in_doc = (
+            await self.chunk_repository.get_by_document_id_order_range(
+                doc_id, range_min, range_max
+            )
+        )
+        if not chunks_in_doc:
+            return results
+
+        chunk_by_order = {c.order: c for c in chunks_in_doc}
+        actual_min = min(chunk_by_order.keys())
+        actual_max = max(chunk_by_order.keys())
 
         # Build ranges
         ranges: list[tuple[int, int, SearchResult]] = []
         passthrough: list[SearchResult] = []
 
         for result in results:
-            chunk = content_to_chunk.get(result.content)
-            if chunk is None:
+            order = id_to_order.get(result.chunk_id)
+            if order is None:
                 passthrough.append(result)
                 continue
-            start = max(min_order, chunk.order - radius)
-            end = min(max_order, chunk.order + radius)
+            start = max(actual_min, order - radius)
+            end = min(actual_max, order + radius)
             ranges.append((start, end, result))
 
         # Merge and build results

--- a/haiku_rag_slim/haiku/rag/client.py
+++ b/haiku_rag_slim/haiku/rag/client.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
     from haiku.rag.agents.rlm.models import RLMResult
 
 logger = logging.getLogger(__name__)
+perf_logger = logging.getLogger("haiku.rag.perf")
 
 
 class RebuildMode(Enum):
@@ -1075,7 +1076,7 @@ class HaikuRAG:
         # Step 1: Get reranker
         t0 = time.perf_counter()
         reranker = get_reranker(config=self._config)
-        logger.info(
+        perf_logger.debug(
             "search.reranker_init took %.3fs",
             time.perf_counter() - t0,
         )
@@ -1086,7 +1087,7 @@ class HaikuRAG:
             chunk_results = await self.chunk_repository.search(
                 query, limit, search_type, filter
             )
-            logger.info(
+            perf_logger.debug(
                 "search.chunk_search type=%s limit=%d results=%d took %.3fs",
                 search_type,
                 limit,
@@ -1098,7 +1099,7 @@ class HaikuRAG:
             raw_results = await self.chunk_repository.search(
                 query, search_limit, search_type, filter
             )
-            logger.info(
+            perf_logger.debug(
                 "search.chunk_search type=%s limit=%d results=%d took %.3fs",
                 search_type,
                 search_limit,
@@ -1110,7 +1111,7 @@ class HaikuRAG:
             t0 = time.perf_counter()
             chunks = [chunk for chunk, _ in raw_results]
             chunk_results = await reranker.rerank(query, chunks, top_n=limit)
-            logger.info(
+            perf_logger.debug(
                 "search.rerank candidates=%d top_n=%d took %.3fs",
                 len(chunks),
                 limit,
@@ -1122,14 +1123,14 @@ class HaikuRAG:
         results = [
             SearchResult.from_chunk(chunk, score) for chunk, score in chunk_results
         ]
-        logger.info(
+        perf_logger.debug(
             "search.build_results count=%d took %.3fs",
             len(results),
             time.perf_counter() - t0,
         )
 
         duration_s = time.perf_counter() - search_start
-        logger.info(
+        perf_logger.debug(
             "search completed query=%r type=%s results=%d duration=%.3fs",
             query[:80],
             search_type,
@@ -1181,7 +1182,7 @@ class HaikuRAG:
         max_chars = self._config.search.max_context_chars
 
         if mode == "disabled":
-            logger.info("expand.disabled, skipping")
+            perf_logger.debug("expand.disabled, skipping")
             return search_results
 
         # Group by document_id for efficient processing
@@ -1192,7 +1193,7 @@ class HaikuRAG:
                 document_groups[doc_id] = []
             document_groups[doc_id].append(result)
 
-        logger.info(
+        perf_logger.debug(
             "expand.groups docs=%d results=%d mode=%s",
             len(document_groups),
             len(search_results),
@@ -1213,7 +1214,7 @@ class HaikuRAG:
                 # Only fetch docling data (skip content blob)
                 t0 = time.perf_counter()
                 doc = await self.document_repository.get_docling_data(doc_id)
-                logger.info(
+                perf_logger.debug(
                     "expand.fetch_docling_data doc=%s took %.3fs",
                     doc_id[:8],
                     time.perf_counter() - t0,
@@ -1221,7 +1222,7 @@ class HaikuRAG:
                 if doc is not None:
                     t0 = time.perf_counter()
                     docling_doc = doc.get_docling_document()
-                    logger.info(
+                    perf_logger.debug(
                         "expand.get_docling_document doc=%s took %.3fs",
                         doc_id[:8],
                         time.perf_counter() - t0,
@@ -1237,7 +1238,7 @@ class HaikuRAG:
                     max_items,
                     max_chars,
                 )
-                logger.info(
+                perf_logger.debug(
                     "expand._expand_with_docling doc=%s results=%d->%d took %.3fs",
                     doc_id[:8],
                     len(doc_results),
@@ -1252,7 +1253,7 @@ class HaikuRAG:
                     expanded = await self._expand_with_chunks(
                         doc_id, doc_results, radius
                     )
-                    logger.info(
+                    perf_logger.debug(
                         "expand._expand_with_chunks doc=%s results=%d->%d took %.3fs",
                         doc_id[:8],
                         len(doc_results),
@@ -1263,7 +1264,7 @@ class HaikuRAG:
                 else:
                     expanded_results.extend(doc_results)
 
-        logger.info(
+        perf_logger.debug(
             "expand.total results=%d took %.3fs",
             len(expanded_results),
             time.perf_counter() - expand_start,

--- a/haiku_rag_slim/haiku/rag/client.py
+++ b/haiku_rag_slim/haiku/rag/client.py
@@ -1075,8 +1075,8 @@ class HaikuRAG:
         # Step 1: Get reranker
         t0 = time.perf_counter()
         reranker = get_reranker(config=self._config)
-        logger.debug(
-            "search reranker_init took %.3fs",
+        logger.info(
+            "search.reranker_init took %.3fs",
             time.perf_counter() - t0,
         )
 
@@ -1086,8 +1086,8 @@ class HaikuRAG:
             chunk_results = await self.chunk_repository.search(
                 query, limit, search_type, filter
             )
-            logger.debug(
-                "search chunk_search type=%s limit=%d results=%d took %.3fs",
+            logger.info(
+                "search.chunk_search type=%s limit=%d results=%d took %.3fs",
                 search_type,
                 limit,
                 len(chunk_results),
@@ -1098,8 +1098,8 @@ class HaikuRAG:
             raw_results = await self.chunk_repository.search(
                 query, search_limit, search_type, filter
             )
-            logger.debug(
-                "search chunk_search type=%s limit=%d results=%d took %.3fs",
+            logger.info(
+                "search.chunk_search type=%s limit=%d results=%d took %.3fs",
                 search_type,
                 search_limit,
                 len(raw_results),
@@ -1112,8 +1112,8 @@ class HaikuRAG:
             chunk_results = await reranker.rerank(
                 query, chunks, top_n=limit
             )
-            logger.debug(
-                "search rerank candidates=%d top_n=%d took %.3fs",
+            logger.info(
+                "search.rerank candidates=%d top_n=%d took %.3fs",
                 len(chunks),
                 limit,
                 time.perf_counter() - t0,
@@ -1125,8 +1125,8 @@ class HaikuRAG:
             SearchResult.from_chunk(chunk, score)
             for chunk, score in chunk_results
         ]
-        logger.debug(
-            "search build_results count=%d took %.3fs",
+        logger.info(
+            "search.build_results count=%d took %.3fs",
             len(results),
             time.perf_counter() - t0,
         )

--- a/haiku_rag_slim/haiku/rag/client.py
+++ b/haiku_rag_slim/haiku/rag/client.py
@@ -1174,6 +1174,10 @@ class HaikuRAG:
         Returns:
             List of SearchResult objects with expanded content and resolved provenance.
         """
+        import time
+
+        expand_start = time.perf_counter()
+
         radius = self._config.search.context_radius
         max_items = self._config.search.max_context_items
         max_chars = self._config.search.max_context_chars
@@ -1185,6 +1189,12 @@ class HaikuRAG:
             if doc_id not in document_groups:
                 document_groups[doc_id] = []
             document_groups[doc_id].append(result)
+
+        logger.info(
+            "expand.groups docs=%d results=%d",
+            len(document_groups),
+            len(search_results),
+        )
 
         expanded_results = []
 
@@ -1198,14 +1208,27 @@ class HaikuRAG:
 
             if has_refs:
                 # Only fetch docling data (skip content blob)
+                t0 = time.perf_counter()
                 doc = await self.document_repository.get_docling_data(
                     doc_id
                 )
+                logger.info(
+                    "expand.fetch_docling_data doc=%s took %.3fs",
+                    doc_id[:8],
+                    time.perf_counter() - t0,
+                )
                 if doc is not None:
+                    t0 = time.perf_counter()
                     docling_doc = doc.get_docling_document()
+                    logger.info(
+                        "expand.decompress_docling doc=%s took %.3fs",
+                        doc_id[:8],
+                        time.perf_counter() - t0,
+                    )
 
             if docling_doc is not None and has_refs:
                 # Use DoclingDocument-based expansion
+                t0 = time.perf_counter()
                 expanded = await self._expand_with_docling(
                     doc_results,
                     docling_doc,
@@ -1213,17 +1236,37 @@ class HaikuRAG:
                     max_items,
                     max_chars,
                 )
+                logger.info(
+                    "expand.docling doc=%s results=%d->%d took %.3fs",
+                    doc_id[:8],
+                    len(doc_results),
+                    len(expanded),
+                    time.perf_counter() - t0,
+                )
                 expanded_results.extend(expanded)
             else:
                 # Fall back to chunk-based expansion (always uses fixed radius)
                 if radius > 0:
+                    t0 = time.perf_counter()
                     expanded = await self._expand_with_chunks(
                         doc_id, doc_results, radius
+                    )
+                    logger.info(
+                        "expand.chunks doc=%s results=%d->%d took %.3fs",
+                        doc_id[:8],
+                        len(doc_results),
+                        len(expanded),
+                        time.perf_counter() - t0,
                     )
                     expanded_results.extend(expanded)
                 else:
                     expanded_results.extend(doc_results)
 
+        logger.info(
+            "expand.total results=%d took %.3fs",
+            len(expanded_results),
+            time.perf_counter() - expand_start,
+        )
         return expanded_results
 
     def _merge_ranges(

--- a/haiku_rag_slim/haiku/rag/config/models.py
+++ b/haiku_rag_slim/haiku/rag/config/models.py
@@ -47,6 +47,8 @@ class StorageConfig(BaseModel):
     data_dir: Path = Field(default_factory=get_default_data_dir)
     auto_vacuum: bool = True
     vacuum_retention_seconds: int = 86400
+    docling_cache_size: int = 100
+    compress_docling: bool = True
 
 
 class MonitorConfig(BaseModel):

--- a/haiku_rag_slim/haiku/rag/config/models.py
+++ b/haiku_rag_slim/haiku/rag/config/models.py
@@ -48,7 +48,6 @@ class StorageConfig(BaseModel):
     auto_vacuum: bool = True
     vacuum_retention_seconds: int = 86400
     docling_cache_size: int = 100
-    compress_docling: bool = True
 
 
 class MonitorConfig(BaseModel):
@@ -176,6 +175,7 @@ class ProcessingConfig(BaseModel):
 class SearchConfig(BaseModel):
     limit: int = 10
     context_radius: int = 0
+    context_expansion_mode: Literal["auto", "chunks", "disabled"] = "auto"
     max_context_items: int = 10
     max_context_chars: int = 10000
     vector_index_metric: Literal["cosine", "l2", "dot"] = "cosine"

--- a/haiku_rag_slim/haiku/rag/store/compression.py
+++ b/haiku_rag_slim/haiku/rag/store/compression.py
@@ -1,28 +1,11 @@
 import gzip
 
-# Gzip magic number: first two bytes of any gzip stream
-_GZIP_MAGIC = b"\x1f\x8b"
 
-
-def compress_json(json_str: str, *, enabled: bool = True) -> bytes:
-    """Compress a JSON string, optionally with gzip.
-
-    Args:
-        json_str: The JSON string to compress.
-        enabled: If False, returns raw UTF-8 bytes without compression.
-    """
-    data = json_str.encode("utf-8")
-    if enabled:
-        return gzip.compress(data)
-    return data
+def compress_json(json_str: str) -> bytes:
+    """Compress a JSON string with gzip."""
+    return gzip.compress(json_str.encode("utf-8"))
 
 
 def decompress_json(data: bytes) -> str:
-    """Decompress data to a JSON string.
-
-    Automatically detects gzip-compressed data via magic bytes,
-    so it handles both compressed and uncompressed storage.
-    """
-    if data[:2] == _GZIP_MAGIC:
-        return gzip.decompress(data).decode("utf-8")
-    return data.decode("utf-8")
+    """Decompress gzip-compressed data to a JSON string."""
+    return gzip.decompress(data).decode("utf-8")

--- a/haiku_rag_slim/haiku/rag/store/compression.py
+++ b/haiku_rag_slim/haiku/rag/store/compression.py
@@ -1,11 +1,28 @@
 import gzip
 
+# Gzip magic number: first two bytes of any gzip stream
+_GZIP_MAGIC = b"\x1f\x8b"
 
-def compress_json(json_str: str) -> bytes:
-    """Compress a JSON string with gzip."""
-    return gzip.compress(json_str.encode("utf-8"))
+
+def compress_json(json_str: str, *, enabled: bool = True) -> bytes:
+    """Compress a JSON string, optionally with gzip.
+
+    Args:
+        json_str: The JSON string to compress.
+        enabled: If False, returns raw UTF-8 bytes without compression.
+    """
+    data = json_str.encode("utf-8")
+    if enabled:
+        return gzip.compress(data)
+    return data
 
 
 def decompress_json(data: bytes) -> str:
-    """Decompress gzip-compressed data to a JSON string."""
-    return gzip.decompress(data).decode("utf-8")
+    """Decompress data to a JSON string.
+
+    Automatically detects gzip-compressed data via magic bytes,
+    so it handles both compressed and uncompressed storage.
+    """
+    if data[:2] == _GZIP_MAGIC:
+        return gzip.decompress(data).decode("utf-8")
+    return data.decode("utf-8")

--- a/haiku_rag_slim/haiku/rag/store/engine.py
+++ b/haiku_rag_slim/haiku/rag/store/engine.py
@@ -107,6 +107,11 @@ class Store:
                 if not db_path.parent.exists():
                     Path.mkdir(db_path.parent, parents=True)
 
+        # Configure docling document cache size from config
+        from haiku.rag.store.models.document import configure_docling_cache
+
+        configure_docling_cache(config.storage.docling_cache_size)
+
         # Connect to LanceDB
         self.db = self._connect_to_lancedb(db_path)
 

--- a/haiku_rag_slim/haiku/rag/store/models/document.py
+++ b/haiku_rag_slim/haiku/rag/store/models/document.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from docling_core.types.doc.document import DoclingDocument
 
 logger = logging.getLogger(__name__)
+perf_logger = logging.getLogger("haiku.rag.perf")
 
 _docling_document_cache: LRUCache[str, "DoclingDocument"] = LRUCache(maxsize=100)
 
@@ -29,7 +30,7 @@ def configure_docling_cache(maxsize: int) -> None:
     # Copy existing entries (LRU order preserved by iteration)
     for key in old:
         _docling_document_cache[key] = old[key]
-    logger.info("docling.cache_resized maxsize=%d", maxsize)
+    perf_logger.debug("docling.cache_resized maxsize=%d", maxsize)
 
 
 def _get_cached_docling_document(
@@ -37,12 +38,12 @@ def _get_cached_docling_document(
 ) -> "DoclingDocument":
     """Get or parse DoclingDocument with LRU caching by document ID."""
     if document_id in _docling_document_cache:
-        logger.info("docling.cache_hit doc=%s", document_id[:8])
+        perf_logger.debug("docling.cache_hit doc=%s", document_id[:8])
         return _docling_document_cache[document_id]
 
     from docling_core.types.doc.document import DoclingDocument
 
-    logger.info(
+    perf_logger.debug(
         "docling.cache_miss doc=%s cache_size=%d/%d",
         document_id[:8],
         len(_docling_document_cache),
@@ -52,7 +53,7 @@ def _get_cached_docling_document(
     t0 = time.perf_counter()
     json_str = decompress_json(compressed_data)
     decompress_time = time.perf_counter() - t0
-    logger.info(
+    perf_logger.debug(
         "docling.decompress doc=%s bytes=%d json_chars=%d took %.3fs",
         document_id[:8],
         len(compressed_data),
@@ -63,7 +64,7 @@ def _get_cached_docling_document(
     t0 = time.perf_counter()
     doc = DoclingDocument.model_validate_json(json_str)
     validate_time = time.perf_counter() - t0
-    logger.info(
+    perf_logger.debug(
         "docling.model_validate doc=%s took %.3fs",
         document_id[:8],
         validate_time,

--- a/haiku_rag_slim/haiku/rag/store/models/document.py
+++ b/haiku_rag_slim/haiku/rag/store/models/document.py
@@ -1,3 +1,5 @@
+import logging
+import time
 from datetime import datetime
 from typing import TYPE_CHECKING
 
@@ -9,6 +11,7 @@ from haiku.rag.store.compression import decompress_json
 if TYPE_CHECKING:
     from docling_core.types.doc.document import DoclingDocument
 
+logger = logging.getLogger(__name__)
 
 _docling_document_cache: LRUCache[str, "DoclingDocument"] = LRUCache(maxsize=100)
 
@@ -18,12 +21,31 @@ def _get_cached_docling_document(
 ) -> "DoclingDocument":
     """Get or parse DoclingDocument with LRU caching by document ID."""
     if document_id in _docling_document_cache:
+        logger.info("docling.cache_hit doc=%s", document_id[:8])
         return _docling_document_cache[document_id]
 
     from docling_core.types.doc.document import DoclingDocument
 
+    t0 = time.perf_counter()
     json_str = decompress_json(compressed_data)
+    decompress_time = time.perf_counter() - t0
+    logger.info(
+        "docling.decompress doc=%s bytes=%d json_chars=%d took %.3fs",
+        document_id[:8],
+        len(compressed_data),
+        len(json_str),
+        decompress_time,
+    )
+
+    t0 = time.perf_counter()
     doc = DoclingDocument.model_validate_json(json_str)
+    validate_time = time.perf_counter() - t0
+    logger.info(
+        "docling.model_validate doc=%s took %.3fs",
+        document_id[:8],
+        validate_time,
+    )
+
     _docling_document_cache[document_id] = doc
     return doc
 

--- a/haiku_rag_slim/haiku/rag/store/models/document.py
+++ b/haiku_rag_slim/haiku/rag/store/models/document.py
@@ -16,6 +16,22 @@ logger = logging.getLogger(__name__)
 _docling_document_cache: LRUCache[str, "DoclingDocument"] = LRUCache(maxsize=100)
 
 
+def configure_docling_cache(maxsize: int) -> None:
+    """Resize the DoclingDocument LRU cache.
+
+    Existing entries are preserved up to the new maxsize.
+    """
+    global _docling_document_cache
+    if _docling_document_cache.maxsize == maxsize:
+        return
+    old = _docling_document_cache
+    _docling_document_cache = LRUCache(maxsize=maxsize)
+    # Copy existing entries (LRU order preserved by iteration)
+    for key in old:
+        _docling_document_cache[key] = old[key]
+    logger.info("docling.cache_resized maxsize=%d", maxsize)
+
+
 def _get_cached_docling_document(
     document_id: str, compressed_data: bytes
 ) -> "DoclingDocument":
@@ -25,6 +41,13 @@ def _get_cached_docling_document(
         return _docling_document_cache[document_id]
 
     from docling_core.types.doc.document import DoclingDocument
+
+    logger.info(
+        "docling.cache_miss doc=%s cache_size=%d/%d",
+        document_id[:8],
+        len(_docling_document_cache),
+        _docling_document_cache.maxsize,
+    )
 
     t0 = time.perf_counter()
     json_str = decompress_json(compressed_data)

--- a/haiku_rag_slim/haiku/rag/store/repositories/chunk.py
+++ b/haiku_rag_slim/haiku/rag/store/repositories/chunk.py
@@ -407,6 +407,44 @@ class ChunkRepository:
             for rec in results
         ]
 
+    async def get_orders_by_ids(self, chunk_ids: list[str]) -> dict[str, int]:
+        """Get order values for specific chunk IDs."""
+        if not chunk_ids:
+            return {}
+        id_list = "', '".join(chunk_ids)
+        rows = list(
+            self.store.chunks_table.search()
+            .select(["id", "order"])
+            .where(f"id IN ('{id_list}')")
+            .to_list()
+        )
+        return {str(row["id"]): int(row["order"]) for row in rows}
+
+    async def get_by_document_id_order_range(
+        self, document_id: str, min_order: int, max_order: int
+    ) -> list[Chunk]:
+        """Get chunks for a document within an order range."""
+        where = (
+            f"document_id = '{document_id}'"
+            f" AND `order` >= {min_order}"
+            f" AND `order` <= {max_order}"
+        )
+        results = list(
+            self.store.chunks_table.search()
+            .where(where)
+            .to_pydantic(self.store.ChunkRecord)
+        )
+        return [
+            Chunk(
+                id=rec.id,
+                document_id=rec.document_id,
+                content=rec.content,
+                metadata=json.loads(rec.metadata),
+                order=rec.order,
+            )
+            for rec in results
+        ]
+
     async def _process_search_results(
         self, query_result: "pd.DataFrame | LanceQueryBuilder"
     ) -> list[tuple[Chunk, float]]:

--- a/haiku_rag_slim/haiku/rag/store/repositories/chunk.py
+++ b/haiku_rag_slim/haiku/rag/store/repositories/chunk.py
@@ -17,6 +17,7 @@ from haiku.rag.store.engine import DocumentRecord, Store
 from haiku.rag.store.models.chunk import Chunk
 
 logger = logging.getLogger(__name__)
+perf_logger = logging.getLogger("haiku.rag.perf")
 
 
 class ChunkRepository:
@@ -255,7 +256,7 @@ class ChunkRepository:
                 return []
             # Keep as pandas Series for efficient vectorized operations
             filtered_doc_ids = docs_df["id"]
-            logger.info(
+            perf_logger.debug(
                 "search.filter docs=%d took %.3fs",
                 len(filtered_doc_ids),
                 time.perf_counter() - t0,
@@ -265,7 +266,7 @@ class ChunkRepository:
         if search_type == "vector":
             t0 = time.perf_counter()
             query_embedding = await self.embedder.embed_query(query)
-            logger.info(
+            perf_logger.debug(
                 "search.embed took %.3fs", time.perf_counter() - t0
             )
             vector_query = cast(
@@ -284,7 +285,7 @@ class ChunkRepository:
         else:  # hybrid (default)
             t0 = time.perf_counter()
             query_embedding = await self.embedder.embed_query(query)
-            logger.info(
+            perf_logger.debug(
                 "search.embed took %.3fs", time.perf_counter() - t0
             )
             # Create RRF reranker
@@ -304,14 +305,14 @@ class ChunkRepository:
         if filtered_doc_ids is not None:
             t0 = time.perf_counter()
             chunks_df = results.to_pandas()
-            logger.info(
+            perf_logger.debug(
                 "search.execute took %.3fs", time.perf_counter() - t0
             )
             t0 = time.perf_counter()
             filtered_chunks_df = chunks_df.loc[
                 chunks_df["document_id"].isin(filtered_doc_ids)
             ].head(limit)
-            logger.info(
+            perf_logger.debug(
                 "search.doc_filter rows=%d->%d took %.3fs",
                 len(chunks_df),
                 len(filtered_chunks_df),
@@ -506,7 +507,7 @@ class ChunkRepository:
             # Convert LanceDB query result to DataFrame
             # (this is where the actual DB query executes)
             df = query_result.to_pandas()
-        logger.info(
+        perf_logger.debug(
             "search.execute rows=%d took %.3fs",
             len(df),
             time.perf_counter() - t0,
@@ -530,7 +531,7 @@ class ChunkRepository:
             )
             for row in rows
         ]
-        logger.info(
+        perf_logger.debug(
             "search.to_records count=%d took %.3fs",
             len(pydantic_results),
             time.perf_counter() - t0,
@@ -552,7 +553,7 @@ class ChunkRepository:
                 .to_pydantic(DocumentRecord)
             )
             documents_map = {doc.id: doc for doc in doc_results}
-        logger.info(
+        perf_logger.debug(
             "search.doc_lookup docs=%d took %.3fs",
             len(documents_map),
             time.perf_counter() - t0,
@@ -575,7 +576,7 @@ class ChunkRepository:
             )
             score = scores[i] if i < len(scores) else 1.0
             chunks_with_scores.append((chunk, score))
-        logger.info(
+        perf_logger.debug(
             "search.build_chunks count=%d took %.3fs",
             len(chunks_with_scores),
             time.perf_counter() - t0,

--- a/haiku_rag_slim/haiku/rag/store/repositories/chunk.py
+++ b/haiku_rag_slim/haiku/rag/store/repositories/chunk.py
@@ -234,10 +234,13 @@ class ChunkRepository:
         Returns:
             List of (chunk, score) tuples ordered by relevance.
         """
+        import time
+
         if not query.strip():
             return []
         filtered_doc_ids = None
         if filter:
+            t0 = time.perf_counter()
             # We perform filtering as a two-step process, first filtering documents, then
             # filtering chunks based on those document IDs.
             # This is because LanceDB does not support joins directly in search queries.
@@ -252,10 +255,19 @@ class ChunkRepository:
                 return []
             # Keep as pandas Series for efficient vectorized operations
             filtered_doc_ids = docs_df["id"]
+            logger.info(
+                "search.filter docs=%d took %.3fs",
+                len(filtered_doc_ids),
+                time.perf_counter() - t0,
+            )
 
         # Prepare search query based on search type
         if search_type == "vector":
+            t0 = time.perf_counter()
             query_embedding = await self.embedder.embed_query(query)
+            logger.info(
+                "search.embed took %.3fs", time.perf_counter() - t0
+            )
             vector_query = cast(
                 "LanceVectorQueryBuilder",
                 self.store.chunks_table.search(
@@ -270,7 +282,11 @@ class ChunkRepository:
             results = self.store.chunks_table.search(query, query_type="fts")
 
         else:  # hybrid (default)
+            t0 = time.perf_counter()
             query_embedding = await self.embedder.embed_query(query)
+            logger.info(
+                "search.embed took %.3fs", time.perf_counter() - t0
+            )
             # Create RRF reranker
             reranker = RRFReranker()
             # Perform native hybrid search with RRF reranking
@@ -286,10 +302,21 @@ class ChunkRepository:
 
         # Apply filtering if needed (common for all search types)
         if filtered_doc_ids is not None:
+            t0 = time.perf_counter()
             chunks_df = results.to_pandas()
+            logger.info(
+                "search.execute took %.3fs", time.perf_counter() - t0
+            )
+            t0 = time.perf_counter()
             filtered_chunks_df = chunks_df.loc[
                 chunks_df["document_id"].isin(filtered_doc_ids)
             ].head(limit)
+            logger.info(
+                "search.doc_filter rows=%d->%d took %.3fs",
+                len(chunks_df),
+                len(filtered_chunks_df),
+                time.perf_counter() - t0,
+            )
             return await self._process_search_results(filtered_chunks_df)
 
         # No filtering needed, apply limit and return
@@ -453,6 +480,8 @@ class ChunkRepository:
         Args:
             query_result: Either a pandas DataFrame or a LanceDB query result
         """
+        import time
+
         import pandas as pd
 
         def extract_scores(df: pd.DataFrame) -> list[float]:
@@ -470,17 +499,25 @@ class ChunkRepository:
                 raise ValueError("Unknown search result format, cannot extract scores")
 
         # Convert everything to DataFrame for uniform processing
+        t0 = time.perf_counter()
         if isinstance(query_result, pd.DataFrame):
             df = query_result
         else:
             # Convert LanceDB query result to DataFrame
+            # (this is where the actual DB query executes)
             df = query_result.to_pandas()
+        logger.info(
+            "search.execute rows=%d took %.3fs",
+            len(df),
+            time.perf_counter() - t0,
+        )
 
         # Extract scores
         scores = extract_scores(df)
 
         # Convert DataFrame rows to ChunkRecords using to_dict
         # (avoids slow .iterrows() overhead)
+        t0 = time.perf_counter()
         rows = df.to_dict(orient="records")
         pydantic_results = [
             self.store.ChunkRecord(
@@ -493,11 +530,17 @@ class ChunkRepository:
             )
             for row in rows
         ]
+        logger.info(
+            "search.to_records count=%d took %.3fs",
+            len(pydantic_results),
+            time.perf_counter() - t0,
+        )
 
         # Collect all unique document IDs for batch lookup
         document_ids = list(set(chunk.document_id for chunk in pydantic_results))
 
         # Batch fetch all documents at once
+        t0 = time.perf_counter()
         documents_map = {}
         if document_ids:
             # Use IN clause for efficient batch lookup
@@ -509,8 +552,14 @@ class ChunkRepository:
                 .to_pydantic(DocumentRecord)
             )
             documents_map = {doc.id: doc for doc in doc_results}
+        logger.info(
+            "search.doc_lookup docs=%d took %.3fs",
+            len(documents_map),
+            time.perf_counter() - t0,
+        )
 
         # Build final results with document info
+        t0 = time.perf_counter()
         chunks_with_scores = []
         for i, chunk_record in enumerate(pydantic_results):
             doc = documents_map.get(chunk_record.document_id)
@@ -526,5 +575,10 @@ class ChunkRepository:
             )
             score = scores[i] if i < len(scores) else 1.0
             chunks_with_scores.append((chunk, score))
+        logger.info(
+            "search.build_chunks count=%d took %.3fs",
+            len(chunks_with_scores),
+            time.perf_counter() - t0,
+        )
 
         return chunks_with_scores

--- a/haiku_rag_slim/haiku/rag/store/repositories/chunk.py
+++ b/haiku_rag_slim/haiku/rag/store/repositories/chunk.py
@@ -366,18 +366,46 @@ class ChunkRepository:
         """Get adjacent chunks before and after the given chunk within the same document."""
         assert chunk.document_id, "Document id is required for adjacent chunk finding"
 
-        chunk_order = chunk.order
+        min_order = chunk.order - num_adjacent
+        max_order = chunk.order + num_adjacent
 
-        # Fetch chunks for the same document and filter by order proximity
-        all_chunks = await self.get_by_document_id(chunk.document_id)
+        # Query only the adjacent chunks directly from the database
+        where = (
+            f"document_id = '{chunk.document_id}'"
+            f" AND `order` >= {min_order}"
+            f" AND `order` <= {max_order}"
+            f" AND id != '{chunk.id}'"
+        )
+        results = list(
+            self.store.chunks_table.search()
+            .where(where)
+            .to_pydantic(self.store.ChunkRecord)
+        )
 
-        adjacent_chunks: list[Chunk] = []
-        for c in all_chunks:
-            c_order = c.order
-            if c.id != chunk.id and abs(c_order - chunk_order) <= num_adjacent:
-                adjacent_chunks.append(c)
+        # Get document info
+        doc_results = list(
+            self.store.documents_table.search()
+            .where(f"id = '{chunk.document_id}'")
+            .limit(1)
+            .to_pydantic(DocumentRecord)
+        )
+        doc_uri = doc_results[0].uri if doc_results else None
+        doc_title = doc_results[0].title if doc_results else None
+        doc_meta = doc_results[0].metadata if doc_results else "{}"
 
-        return adjacent_chunks
+        return [
+            Chunk(
+                id=rec.id,
+                document_id=rec.document_id,
+                content=rec.content,
+                metadata=json.loads(rec.metadata),
+                order=rec.order,
+                document_uri=doc_uri,
+                document_title=doc_title,
+                document_meta=json.loads(doc_meta),
+            )
+            for rec in results
+        ]
 
     async def _process_search_results(
         self, query_result: "pd.DataFrame | LanceQueryBuilder"
@@ -413,7 +441,9 @@ class ChunkRepository:
         # Extract scores
         scores = extract_scores(df)
 
-        # Convert DataFrame rows to ChunkRecords
+        # Convert DataFrame rows to ChunkRecords using to_dict
+        # (avoids slow .iterrows() overhead)
+        rows = df.to_dict(orient="records")
         pydantic_results = [
             self.store.ChunkRecord(
                 id=str(row["id"]),
@@ -423,7 +453,7 @@ class ChunkRepository:
                 metadata=str(row["metadata"]),
                 order=int(row["order"]) if "order" in row else 0,
             )
-            for _, row in df.iterrows()
+            for row in rows
         ]
 
         # Collect all unique document IDs for batch lookup

--- a/haiku_rag_slim/haiku/rag/store/repositories/document.py
+++ b/haiku_rag_slim/haiku/rag/store/repositories/document.py
@@ -90,6 +90,30 @@ class DocumentRepository:
 
         return self._record_to_document(results[0])
 
+    _DOCLING_COLUMNS = ["id", "docling_document", "docling_version"]
+
+    async def get_docling_data(self, entity_id: str) -> Document | None:
+        """Get document with only docling data loaded (skips content blob)."""
+        safe_id = _escape_sql_string(entity_id)
+        results = list(
+            self.store.documents_table.search()
+            .select(self._DOCLING_COLUMNS)
+            .where(f"id = '{safe_id}'")
+            .limit(1)
+            .to_list()
+        )
+
+        if not results:
+            return None
+
+        row = results[0]
+        return Document(
+            id=row["id"],
+            content="",
+            docling_document=row.get("docling_document"),
+            docling_version=row.get("docling_version"),
+        )
+
     async def update(self, entity: Document) -> Document:
         """Update an existing document."""
         self.store._assert_writable()

--- a/haiku_rag_slim/haiku/rag/tools/search.py
+++ b/haiku_rag_slim/haiku/rag/tools/search.py
@@ -9,6 +9,7 @@ from haiku.rag.store.models import SearchResult
 from haiku.rag.tools.context import RAGDeps
 
 logger = logging.getLogger(__name__)
+perf_logger = logging.getLogger("haiku.rag.perf")
 
 
 def create_search_toolset(
@@ -59,7 +60,7 @@ def create_search_toolset(
 
         if _last_tool_return:
             llm_think_time = tool_start - _last_tool_return[0]
-            logger.info(
+            perf_logger.debug(
                 "tool.llm_thinking took %.3fs", llm_think_time
             )
 
@@ -81,7 +82,7 @@ def create_search_toolset(
         results = await client.search(
             query, limit=effective_limit, filter=effective_filter
         )
-        logger.info(
+        perf_logger.debug(
             "tool.search query=%r took %.3fs",
             query[:80],
             time.perf_counter() - t0,
@@ -90,7 +91,7 @@ def create_search_toolset(
         if expand_context:
             t0 = time.perf_counter()
             results = await client.expand_context(results)
-            logger.info(
+            perf_logger.debug(
                 "tool.expand_context results=%d took %.3fs",
                 len(results),
                 time.perf_counter() - t0,
@@ -112,14 +113,14 @@ def create_search_toolset(
             for i, r in enumerate(results_list)
         ]
         output = "\n\n".join(formatted)
-        logger.info(
+        perf_logger.debug(
             "tool.format results=%d chars=%d took %.3fs",
             total,
             len(output),
             time.perf_counter() - t0,
         )
 
-        logger.info(
+        perf_logger.debug(
             "tool.search_total took %.3fs",
             time.perf_counter() - tool_start,
         )

--- a/haiku_rag_slim/haiku/rag/tools/search.py
+++ b/haiku_rag_slim/haiku/rag/tools/search.py
@@ -1,3 +1,5 @@
+import logging
+import time
 from collections.abc import Callable
 
 from pydantic_ai import FunctionToolset, RunContext
@@ -5,6 +7,8 @@ from pydantic_ai import FunctionToolset, RunContext
 from haiku.rag.config.models import AppConfig
 from haiku.rag.store.models import SearchResult
 from haiku.rag.tools.context import RAGDeps
+
+logger = logging.getLogger(__name__)
 
 
 def create_search_toolset(
@@ -35,6 +39,7 @@ def create_search_toolset(
     # Per-run search counter keyed by run_id. Safe for concurrent runs
     # and reuse across sequential agent.run() calls.
     search_counts: dict[str, int] = {}
+    _last_tool_return: list[float] = []
 
     async def search(
         ctx: RunContext[RAGDeps],
@@ -50,9 +55,18 @@ def create_search_toolset(
         Returns:
             Formatted search results with content and metadata.
         """
+        tool_start = time.perf_counter()
+
+        if _last_tool_return:
+            llm_think_time = tool_start - _last_tool_return[0]
+            logger.info(
+                "tool.llm_thinking took %.3fs", llm_think_time
+            )
+
         rid = ctx.run_id or ""
         search_counts[rid] = search_counts.get(rid, 0) + 1
         if max_searches is not None and search_counts[rid] > max_searches:
+            _last_tool_return[:] = [time.perf_counter()]
             return (
                 "Search limit reached. "
                 "Answer the question using the results you already have."
@@ -62,12 +76,25 @@ def create_search_toolset(
 
         effective_filter = base_filter
         effective_limit = limit or config.search.limit
+
+        t0 = time.perf_counter()
         results = await client.search(
             query, limit=effective_limit, filter=effective_filter
         )
+        logger.info(
+            "tool.search query=%r took %.3fs",
+            query[:80],
+            time.perf_counter() - t0,
+        )
 
         if expand_context:
+            t0 = time.perf_counter()
             results = await client.expand_context(results)
+            logger.info(
+                "tool.expand_context results=%d took %.3fs",
+                len(results),
+                time.perf_counter() - t0,
+            )
 
         results_list = list(results)
 
@@ -75,14 +102,29 @@ def create_search_toolset(
             on_results(results_list)
 
         if not results_list:
+            _last_tool_return[:] = [time.perf_counter()]
             return "No results found."
 
+        t0 = time.perf_counter()
         total = len(results_list)
         formatted = [
             r.format_for_agent(rank=i + 1, total=total)
             for i, r in enumerate(results_list)
         ]
-        return "\n\n".join(formatted)
+        output = "\n\n".join(formatted)
+        logger.info(
+            "tool.format results=%d chars=%d took %.3fs",
+            total,
+            len(output),
+            time.perf_counter() - t0,
+        )
+
+        logger.info(
+            "tool.search_total took %.3fs",
+            time.perf_counter() - tool_start,
+        )
+        _last_tool_return[:] = [time.perf_counter()]
+        return output
 
     toolset: FunctionToolset[RAGDeps] = FunctionToolset()
     toolset.add_function(search, name=tool_name, retries=3)

--- a/tests/test_context_enhancement.py
+++ b/tests/test_context_enhancement.py
@@ -768,3 +768,81 @@ async def test_expand_context_no_base64_images_docling_serve(temp_db_path):
                 assert "data:image" not in result.content.lower(), (
                     f"Found 'data:image' in expanded content: {result.content[:500]}"
                 )
+
+
+async def test_expand_context_disabled_mode(temp_db_path):
+    """Test that context_expansion_mode='disabled' returns results unchanged."""
+    config = AppConfig()
+    config.search.context_radius = 3
+    config.search.context_expansion_mode = "disabled"
+
+    async with HaikuRAG(temp_db_path, config=config, create=True) as client:
+        # Build SearchResults directly — no DB or embeddings needed
+        search_results = [
+            SearchResult(
+                content="Test content",
+                score=0.9,
+                chunk_id="chunk-1",
+                document_id="doc-1",
+            ),
+            SearchResult(
+                content="Other content",
+                score=0.8,
+                chunk_id="chunk-2",
+                document_id="doc-1",
+            ),
+        ]
+        expanded = await client.expand_context(search_results)
+
+        # Should return the exact same list — no expansion performed
+        assert len(expanded) == 2
+        assert expanded[0].content == "Test content"
+        assert expanded[0].score == 0.9
+        assert expanded[1].content == "Other content"
+        assert expanded[1].score == 0.8
+
+
+@pytest.mark.vcr()
+async def test_expand_context_chunks_mode_skips_docling(temp_db_path):
+    """Test that context_expansion_mode='chunks' uses chunk expansion."""
+    config = AppConfig()
+    config.search.context_radius = 1
+    config.search.context_expansion_mode = "chunks"
+
+    async with HaikuRAG(temp_db_path, config=config, create=True) as client:
+        # Create document with manual chunks that have pre-set embeddings
+        # to avoid calling the embedding API
+        dim = 2560
+        docling_doc = DoclingDocument(name="test_chunks_mode")
+        docling_doc.add_text(label=DocItemLabel.TEXT, text="Full content")
+        manual_chunks = [
+            Chunk(content="Part A", order=0, embedding=[0.1] * dim),
+            Chunk(content="Part B", order=1, embedding=[0.2] * dim),
+            Chunk(content="Part C", order=2, embedding=[0.3] * dim),
+        ]
+        doc = await client.import_document(
+            docling_document=docling_doc, chunks=manual_chunks
+        )
+        assert doc.id is not None
+
+        chunks = await client.chunk_repository.get_by_document_id(doc.id)
+        chunk_b = next(c for c in chunks if c.order == 1)
+
+        # Give it doc_item_refs so it would normally trigger docling path
+        search_results = [
+            SearchResult(
+                content=chunk_b.content,
+                score=0.9,
+                chunk_id=chunk_b.id,
+                document_id=doc.id,
+                doc_item_refs=["#/texts/0"],
+            ),
+        ]
+        expanded = await client.expand_context(search_results)
+
+        # Should use chunk-based expansion (radius=1 around order 1)
+        assert len(expanded) == 1
+        # Expanded content should include adjacent chunks
+        assert "Part A" in expanded[0].content
+        assert "Part B" in expanded[0].content
+        assert "Part C" in expanded[0].content


### PR DESCRIPTION
This pull request is intended to mitigate performance issues around loading the full document content for docling-based expansion. For large documents, uncompression can take as much as 5 seconds and loading the model can take another 5, where loading adjacent chunks is faster.  This pull request also introduces optimizations to retrieving adjacent chunks.


- Performance improvements to neighboring chunk fetching.
- Add configuration to control context expansion behavior
- Add performance logging 

The table below is  the results of comparing the behaviors of the new extension filtering vs the current main branch. The
[haiku.rag.yaml](https://github.com/user-attachments/files/26525754/haiku.rag.yaml) was changed to select each of the options (or switch to main branch) and a panel of 5 questions were run 5 times each using haiku-rag ask and the elapsed time aggregated. The relevant parts of the configuration are:
```
search:
  limit: 10
  context_radius: 2
  context_expansion_mode: chunks
  max_context_items: 0
  max_context_chars: 0
  vector_index_metric: cosine
  vector_refine_factor: 30
```

The results indicate that disabling extension results in significant improvement in query time with chunks only also showing improvements.  Auto and main are similar which is expected as they are using the same code paths.

| question_num | setting | mean | std | count |
|---|---|---|---|---|
| 0 | auto | 53.64 | 10.72 | 5 |
| 0 | chunks | 32.55 | 15.99 | 5 |
| 0 | disabled | 28.27 | 7.35 | 5 |
| 0 | main | 52.07 | 15.02 | 5 |
| 1 | auto | 38.96 | 2.75 | 5 |
| 1 | chunks | 21.79 | 6.61 | 5 |
| 1 | disabled | 15.57 | 3.57 | 5 |
| 1 | main | 34.39 | 7.11 | 5 |
| 2 | auto | 43.39 | 25.28 | 5 |
| 2 | chunks | 39.91 | 10.65 | 5 |
| 2 | disabled | 40.71 | 28.2 | 5 |
| 2 | main | 23.7 | 1.51 | 5 |
| 3 | auto | 21.69 | 6.05 | 5 |
| 3 | chunks | 21.78 | 5.28 | 5 |
| 3 | disabled | 18.15 | 4.62 | 5 |
| 3 | main | 27.74 | 7.08 | 5 |
| 4 | auto | 32.83 | 3.37 | 5 |
| 4 | chunks | 18.83 | 1.67 | 5 |
| 4 | disabled | 31.14 | 21.64 | 5 |
| 4 | main | 34.51 | 2.37 | 5 |