### PR TITLE
fix: classify FileNotFoundError as PermanentError

### DIFF
--- a/haiku_rag_slim/haiku/rag/ingester/workers/pipeline.py
+++ b/haiku_rag_slim/haiku/rag/ingester/workers/pipeline.py
@@ -57,6 +57,9 @@ def _classify(exc: BaseException) -> Exception:
         # ProxyError — every transport-layer failure that's worth retrying.
         return TransientError(f"network: {exc}")
 
+    if isinstance(exc, FileNotFoundError):
+        return PermanentError(f"file not found: {exc}")
+
     if isinstance(exc, asyncio.TimeoutError | TimeoutError | OSError):
         return TransientError(f"timeout/io: {exc}")
 

--- a/tests/ingester/test_pipeline.py
+++ b/tests/ingester/test_pipeline.py
@@ -261,3 +261,12 @@ async def test_existing_permanent_error_passes_through_unchanged():
     with pytest.raises(PermanentError) as excinfo:
         await run_job(client, _job())
     assert excinfo.value is sentinel
+
+
+@pytest.mark.asyncio
+async def test_file_not_found_classified_as_permanent():
+    """A deleted file should go straight to the DLQ, not retry."""
+    client = _mock_client()
+    client.create_document_from_source.side_effect = FileNotFoundError("gone")
+    with pytest.raises(PermanentError, match="file not found"):
+        await run_job(client, _job())


### PR DESCRIPTION
## Summary
- `FileNotFoundError` is a subclass of `OSError`, so it was caught by the broad `timeout/io` handler and classified as `TransientError`
- A file deleted between discovery and fetch would waste all 5 retry attempts on a file that's permanently gone
- Add an explicit `FileNotFoundError` check before the `OSError` catch so deleted files go straight to the DLQ

## Test plan
- [x] All 303 existing ingester tests pass
- [x] 1 new test verifying `FileNotFoundError` raises `PermanentError`