### PR TITLE
fix: watch loop crash when file deleted before stat() in _handle_watch_change

### DIFF
--- a/haiku_rag_slim/haiku/rag/ingester/pollers/fs.py
+++ b/haiku_rag_slim/haiku/rag/ingester/pollers/fs.py
@@ -131,7 +131,12 @@ class FSPoller(BasePoller):
                 return
 
             if change in (Change.added, Change.modified):
-                revision = str(path.stat().st_mtime_ns) if path.exists() else None
+                try:
+                    revision = str(path.stat().st_mtime_ns)
+                except FileNotFoundError:
+                    # File was deleted between the watchfiles event and our
+                    # stat() call.  Skip — the deletion event will handle it.
+                    return
                 await self._jobs.enqueue(
                     self.source_id,
                     uri,

--- a/tests/ingester/test_pollers.py
+++ b/tests/ingester/test_pollers.py
@@ -484,6 +484,22 @@ async def test_watch_deleted_then_added_enqueues_upsert(tmp_path, jobs, sync):
     assert queued[0].op is JobOp.UPSERT
 
 
+@pytest.mark.asyncio
+async def test_watch_added_file_deleted_before_stat_does_not_crash(tmp_path, jobs, sync):
+    """If a file is deleted between the watchfiles event and the stat()
+    call, the handler should return silently instead of raising
+    FileNotFoundError and killing the watch loop."""
+    from watchfiles import Change
+
+    poller = _fs_poller(tmp_path, jobs, sync)
+    missing = tmp_path / "vanished.md"
+    # File doesn't exist — simulate Change.added arriving after deletion.
+    await poller._handle_watch_change(Change.added, missing)
+
+    # No job should be enqueued, and no exception should have propagated.
+    assert await jobs.list_jobs(source_id="local") == []
+
+
 # --- FSPoller end-to-end smoke ---
 
 


### PR DESCRIPTION
## Summary
- `_handle_watch_change` used `str(path.stat().st_mtime_ns) if path.exists() else None` which has a TOCTOU race
- File deleted between `exists()` and `stat()` raises `FileNotFoundError`
- This propagates to `_watch_loop`'s exception handler, which records a breaker failure and **terminates the loop** — no more push events until restart
- Now catches `FileNotFoundError` around `stat()` and returns early; the deletion event handles cleanup

## Test plan
- [x] All 303 existing ingester tests pass
- [x] 1 new test: calls `_handle_watch_change(Change.added, missing_path)` and verifies no exception and no job enqueued