### PR TITLE
fix: classify PermissionError as PermanentError

### DIFF
--- a/haiku_rag_slim/haiku/rag/ingester/workers/pipeline.py
+++ b/haiku_rag_slim/haiku/rag/ingester/workers/pipeline.py
@@ -60,6 +60,9 @@ def _classify(exc: BaseException) -> Exception:
     if isinstance(exc, FileNotFoundError):
         return PermanentError(f"file not found: {exc}")
 
+    if isinstance(exc, PermissionError):
+        return PermanentError(f"permission denied: {exc}")
+
     if isinstance(exc, asyncio.TimeoutError | TimeoutError | OSError):
         return TransientError(f"timeout/io: {exc}")
 

--- a/tests/ingester/test_pipeline.py
+++ b/tests/ingester/test_pipeline.py
@@ -270,3 +270,12 @@ async def test_file_not_found_classified_as_permanent():
     client.create_document_from_source.side_effect = FileNotFoundError("gone")
     with pytest.raises(PermanentError, match="file not found"):
         await run_job(client, _job())
+
+
+@pytest.mark.asyncio
+async def test_permission_error_classified_as_permanent():
+    """An unreadable file should go straight to the DLQ, not retry."""
+    client = _mock_client()
+    client.create_document_from_source.side_effect = PermissionError("no access")
+    with pytest.raises(PermanentError, match="permission denied"):
+        await run_job(client, _job())


### PR DESCRIPTION
## Summary
- `PermissionError` is a subclass of `OSError`, so it was caught by the broad `timeout/io` handler and classified as `TransientError`
- An unreadable file would waste all retry attempts then DLQ — permissions don't fix themselves without operator action
- Add an explicit `PermissionError` check before the `OSError` catch so unreadable files go straight to the DLQ

## Test plan
- [x] All 303 existing ingester tests pass
- [x] 1 new test verifying `PermissionError` raises `PermanentError`