### PR TITLE
fix: narrow HTTP discover() exception catch to TransportError

### DIFF
--- a/haiku_rag_slim/haiku/rag/ingester/sources/http.py
+++ b/haiku_rag_slim/haiku/rag/ingester/sources/http.py
@@ -1,4 +1,5 @@
 import hashlib
+import logging
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
 from urllib.parse import urlparse
@@ -11,6 +12,8 @@ from haiku.rag.ingester.sources.base import (
     SourceEvent,
     SourceEventKind,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def _extract_revision(headers: httpx.Headers) -> tuple[str | None, dict[str, str]]:
@@ -103,7 +106,12 @@ class HTTPSource:
         for url in self.urls:
             try:
                 head = await self._http.head(url)
-            except Exception:
+            except httpx.TransportError as exc:
+                logger.debug(
+                    "HEAD %s failed (%s); emitting UPSERT with no revision",
+                    url,
+                    exc,
+                )
                 yield SourceEvent(
                     source_id=self.source_id,
                     uri=url,

--- a/tests/ingester/test_http_source.py
+++ b/tests/ingester/test_http_source.py
@@ -324,3 +324,21 @@ async def test_discover_emits_delete_for_removed_url_with_no_revision_tracked():
     ]
     by_uri = {e.uri: e for e in events}
     assert by_uri["https://example.com/no-etag.md"].kind is SourceEventKind.DELETE
+
+
+@pytest.mark.asyncio
+async def test_discover_propagates_non_transport_errors():
+    """Programming errors (TypeError, etc.) should propagate instead of
+    being silently swallowed as UPSERT events."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise TypeError("unexpected bug")
+
+    src = HTTPSource(
+        source_id="x",
+        urls=["https://example.com/a.md"],
+        transport=httpx.MockTransport(handler),
+    )
+    with pytest.raises(TypeError, match="unexpected bug"):
+        async for _ in src.discover():
+            pass


### PR DESCRIPTION
## Summary
- The bare `except Exception` in `HTTPSource.discover()` silently swallowed all errors from HEAD requests — including configuration errors and programming errors — treating them as network failures
- Narrowed to `except httpx.TransportError` (ConnectError, TimeoutException, etc.) with a debug log
- Other exceptions now propagate to the poller's circuit breaker where they surface as failures

## Test plan
- [x] All 303 existing ingester tests pass (including the existing `ConnectError` test)
- [x] 1 new test verifying non-transport errors (e.g. `TypeError`) propagate instead of being swallowed