### PR TITLE
fix: classify IsADirectoryError and NotADirectoryError as PermanentError

### DIFF
--- a/haiku_rag_slim/haiku/rag/ingester/workers/pipeline.py
+++ b/haiku_rag_slim/haiku/rag/ingester/workers/pipeline.py
@@ -63,6 +63,9 @@ def _classify(exc: BaseException) -> Exception:
     if isinstance(exc, PermissionError):
         return PermanentError(f"permission denied: {exc}")
 
+    if isinstance(exc, IsADirectoryError | NotADirectoryError):
+        return PermanentError(f"path error: {exc}")
+
     if isinstance(exc, asyncio.TimeoutError | TimeoutError | OSError):
         return TransientError(f"timeout/io: {exc}")
 

--- a/tests/ingester/test_pipeline.py
+++ b/tests/ingester/test_pipeline.py
@@ -279,3 +279,13 @@ async def test_permission_error_classified_as_permanent():
     client.create_document_from_source.side_effect = PermissionError("no access")
     with pytest.raises(PermanentError, match="permission denied"):
         await run_job(client, _job())
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exc_class", [IsADirectoryError, NotADirectoryError])
+async def test_directory_errors_classified_as_permanent(exc_class):
+    """Pointing at a directory instead of a file should DLQ immediately."""
+    client = _mock_client()
+    client.create_document_from_source.side_effect = exc_class("not a file")
+    with pytest.raises(PermanentError, match="path error"):
+        await run_job(client, _job())


### PR DESCRIPTION
## Summary
- Both are `OSError` subclasses caught by the broad `timeout/io` handler and classified as transient
- Pointing at a directory instead of a file will never succeed on retry — should go straight to DLQ

## Test plan
- [x] All 303 existing ingester tests pass
- [x] 2 new parametrized tests (one for each error class)