### PR TITLE
improve concurrency management for pdf attachments

### DIFF
--- a/haiku_rag_slim/haiku/rag/client/documents.py
+++ b/haiku_rag_slim/haiku/rag/client/documents.py
@@ -1,3 +1,4 @@
+import asyncio
 import hashlib
 import json
 import logging
@@ -543,7 +544,9 @@ async def _reconcile_pdf_attachments(
     if (parent_doc.metadata or {}).get("content_type") != "application/pdf":
         return
 
-    new_attachments = _extract_pdf_attachments(parent_body, parent_doc.uri, depth=depth)
+    new_attachments = await asyncio.to_thread(
+        _extract_pdf_attachments, parent_body, parent_doc.uri, depth=depth
+    )
     if new_attachments is None:
         return
 

--- a/tests/test_pdf_attachments.py
+++ b/tests/test_pdf_attachments.py
@@ -1,10 +1,12 @@
 import io
+import threading
 
 import pypdfium2 as pdfium
 
 from haiku.rag.client import HaikuRAG
 from haiku.rag.client.documents import (
     MAX_ATTACHMENT_DEPTH,
+    _extract_pdf_attachments,
     _reconcile_pdf_attachments,
     parent_uri_filter,
 )
@@ -482,3 +484,37 @@ async def test_create_document_from_source_delete_cascades(
 
         await client.delete_document(parent.id)
         assert await client.list_documents() == []
+
+
+async def test_extract_pdf_attachments_called_off_event_loop_thread(
+    temp_db_path, monkeypatch
+):
+    """_extract_pdf_attachments must run in a thread-pool thread, not on the
+    event-loop thread. A synchronous call would freeze the event loop for the
+    duration of pdfium I/O, stalling every other concurrent worker.
+
+    We verify this by capturing the thread identity inside a spy wrapper: if
+    asyncio.to_thread is used correctly the spy runs on a non-main thread."""
+    called_from: list[threading.Thread] = []
+
+    def spy(body, uri, *, depth):
+        called_from.append(threading.current_thread())
+        return _extract_pdf_attachments(body, uri, depth=depth)
+
+    monkeypatch.setattr("haiku.rag.client.documents._extract_pdf_attachments", spy)
+    monkeypatch.setattr(
+        "haiku.rag.client.documents._ingest_fetch_result",
+        fake_ingest_fetch_result,
+    )
+
+    pdf_bytes = build_pdf([("a.txt", b"payload")])
+    async with HaikuRAG(temp_db_path, create=True) as client:
+        parent_uri = "file:///fixtures/parent.pdf"
+        parent = await _make_parent(client, parent_uri, pdf_bytes)
+        await _reconcile_pdf_attachments(client, parent, pdf_bytes, depth=0)
+
+    assert called_from, "_extract_pdf_attachments was never called"
+    assert called_from[0] is not threading.main_thread(), (
+        "_extract_pdf_attachments ran on the event-loop thread; "
+        "it must be dispatched via asyncio.to_thread to avoid blocking the loop"
+    )


### PR DESCRIPTION
# fix: dispatch `_extract_pdf_attachments` via `asyncio.to_thread`

## Problem

`_reconcile_pdf_attachments` called `_extract_pdf_attachments` synchronously
from the async pipeline:

```python
# before
new_attachments = _extract_pdf_attachments(parent_body, parent_doc.uri, depth=depth)
```

`_extract_pdf_attachments` is a synchronous function that holds `PDFIUM_LOCK`
(a `threading.Lock`) for its entire body — opening the PDF with
`pdfium.PdfDocument(bytes)`, iterating every embedded attachment, and
extracting each attachment's bytes via `att.get_data()`. Running this on the
event-loop thread blocks the loop for the full duration of pdfium I/O.

During that block:
- All other concurrent worker coroutines are suspended, regardless of where
  they are in the pipeline.
- Any `asyncio.to_thread` results waiting in the thread pool (e.g. completed
  docling conversions) cannot be delivered back to their awaiters.
- The `asyncio.sleep(0.1)` polling loop in `run_batch` cannot fire.

In `run-batch` mode the full corpus is queued in one sweep, so all four workers
start processing simultaneously. When several workers reach PDFs with embedded
attachments at roughly the same time, the event loop freezes repeatedly —
once per document with attachments, serially — producing the thousand-second
store-step delays observed in practice.

## Fix

Dispatch the call through `asyncio.to_thread`, matching the pattern already
used by `convert_pdf_with_splitting` for `_next` and `it.close`:

```python
# after
new_attachments = await asyncio.to_thread(
    _extract_pdf_attachments, parent_body, parent_doc.uri, depth=depth
)
```

`_extract_pdf_attachments` is self-contained (no async internals) and
thread-safe under `PDFIUM_LOCK`, so the only requirement for correctness in a
thread is that the lock is acquired before any pdfium call — which it already
is throughout the function body. The event loop is now free to service other
coroutines while the thread waits for and holds the lock.

## Test

`test_extract_pdf_attachments_called_off_event_loop_thread` in
`tests/test_pdf_attachments.py` installs a spy around
`_extract_pdf_attachments` that records `threading.current_thread()` at call
time, then asserts the recorded thread is not `threading.main_thread()`. This
directly tests the dispatch mechanism: a regression back to a synchronous call
will fail the assertion with a clear message, independent of document size or
timing.

## Files changed

- `haiku_rag_slim/haiku/rag/client/documents.py` — `import asyncio`; wrap
  `_extract_pdf_attachments` call in `await asyncio.to_thread(...)`
- `tests/test_pdf_attachments.py` — new threading-identity test
