### PR TITLE
Thread extract_items off the asyncio event loop

### DIFF
--- a/haiku_rag_slim/haiku/rag/client/documents.py
+++ b/haiku_rag_slim/haiku/rag/client/documents.py
@@ -118,6 +118,7 @@ async def _store_document_with_chunks(
     Handles versioning/rollback on failure.
     """
     chunks = await ensure_chunks_embedded(client._config, chunks, client.embedder)
+    items = await asyncio.to_thread(extract_items, "", docling_document)
 
     async with client.store._write_lock:
         versions = await client.store.current_table_versions()
@@ -134,7 +135,8 @@ async def _store_document_with_chunks(
 
             await client.chunk_repository.create(chunks)
 
-            items = extract_items(created_doc.id, docling_document)
+            for item in items:
+                item.document_id = created_doc.id
             await client.document_item_repository.create_items(created_doc.id, items)
 
             if client._config.storage.auto_vacuum:
@@ -170,6 +172,12 @@ async def _update_document_with_chunks(
 
     chunks = await ensure_chunks_embedded(client._config, chunks, client.embedder)
 
+    items: list | None = None
+    if docling_document is not None:
+        items = await asyncio.to_thread(
+            extract_items, document.id, docling_document, existing_picture_data
+        )
+
     async with client.store._write_lock:
         versions = await client.store.current_table_versions()
 
@@ -183,12 +191,7 @@ async def _update_document_with_chunks(
 
             await client.chunk_repository.replace_for_document(updated_doc.id, chunks)
 
-            if docling_document is not None:
-                items = extract_items(
-                    updated_doc.id,
-                    docling_document,
-                    existing_picture_data=existing_picture_data,
-                )
+            if items is not None:
                 await client.document_item_repository.replace_for_document(
                     updated_doc.id, items
                 )
@@ -279,6 +282,11 @@ async def _store_documents_with_chunks(
         for _, chunks, _ in prepared
     ]
 
+    def _extract_all_items():
+        return [extract_items("", d) for _, _, d in prepared]
+
+    all_item_lists = await asyncio.to_thread(_extract_all_items)
+
     async with client.store._write_lock:
         versions = await client.store.current_table_versions()
 
@@ -289,15 +297,17 @@ async def _store_documents_with_chunks(
         try:
             all_chunks: list[Chunk] = []
             all_items = []
-            for doc, doc_chunks, docling_document in zip(
-                created, embedded, (d for _, _, d in prepared)
+            for doc, doc_chunks, item_list in zip(
+                created, embedded, all_item_lists
             ):
                 assert doc.id is not None
                 for order, chunk in enumerate(doc_chunks):
                     chunk.document_id = doc.id
                     chunk.order = order
                 all_chunks.extend(doc_chunks)
-                all_items.extend(extract_items(doc.id, docling_document))
+                for item in item_list:
+                    item.document_id = doc.id
+                all_items.extend(item_list)
 
             await client.chunk_repository.create(all_chunks)
             await client.document_item_repository.create_all(all_items)


### PR DESCRIPTION
## Summary

Bryan identified this via py-spy thread stack:

```
$ uvx py-spy dump --pid=2594957
Process 2594957: /app/.venv/bin/python /app/.venv/bin/haiku-ingester --config=/haiku/haiku.rag.default.yaml run-batch --db=/lancedb/u28-webdav.lancedb
Python v3.13.12 (/usr/local/bin/python3.13)

Thread 350 (active+gil): "MainThread"
    __copy__ (pydantic/main.py:974)
    model_copy (pydantic/main.py:412)
    _clamp_bbox_to_page (docling_core/types/doc/document.py:2969)
    _clamp_provenance_bbox_to_page (docling_core/types/doc/document.py:3012)
    clamp_prov (docling_core/types/doc/document.py:3023)
    _clamp_provenance_bboxes_to_pages (docling_core/types/doc/document.py:3056)
    validate_document (docling_core/types/doc/document.py:7678)
    __init__ (pydantic/main.py:263)
    export_to_markdown (docling_core/types/doc/document.py:2513)
    extract_item_text (rag/store/models/document_item.py:84)
    extract_items (rag/store/models/document_item.py:123)
    _store_document_with_chunks (rag/client/documents.py:137)
    _ingest_fetch_result (rag/client/documents.py:492)
    create_document_from_source (rag/client/documents.py:787)
    create_document_from_source (rag/client/__init__.py:287)
    run_job (rag/ingester/workers/pipeline.py:145)
    _process (rag/ingester/workers/pool.py:191)
    _worker_loop (rag/ingester/workers/pool.py:164)
    _run (asyncio/events.py:89)
    _run_once (asyncio/base_events.py:2050)
    run_forever (asyncio/base_events.py:683)
    run_until_complete (asyncio/base_events.py:712)
    run (asyncio/runners.py:118)
    run (asyncio/runners.py:195)
    run_batch (rag/ingester/cli.py:294)
    wrapper (typer/main.py:1511)
    invoke (click/core.py:877)
    invoke (click/core.py:1308)
    invoke (click/core.py:1912)
    _main (typer/core.py:190)
    main (typer/core.py:814)
    __call__ (click/core.py:1524)
    __call__ (typer/main.py:1132)
    cli (rag/ingester/cli.py:73)
    <module> (haiku-ingester:10)
```
The PR:

- Moves CPU-bound `extract_items` calls into worker threads via `asyncio.to_thread` so the event loop stays responsive during ingestion
- Hoists `extract_items` out of the `_write_lock` in all three call sites (`_store_document_with_chunks`, `_update_document_with_chunks`, `_store_documents_with_chunks`) — it's pure computation with no DB I/O
- Pre-computes items with placeholder document IDs, then patches real IDs after DB create returns

## Test plan

- [ ] Existing test suite passes
- [ ] Ingester processes documents without errors under load
- [ ] py-spy dump no longer shows the event loop blocked in `_clamp_provenance_bboxes_to_pages`

Fixes #453
