### PR TITLE
Thread chunker.chunk() off the asyncio event loop

### DIFF
--- a/haiku_rag_slim/haiku/rag/chunkers/base.py
+++ b/haiku_rag_slim/haiku/rag/chunkers/base.py
@@ -15,7 +15,7 @@ class DocumentChunker(ABC):
     """
 
     @abstractmethod
-    async def chunk(self, document: "DoclingDocument") -> list["Chunk"]:
+    async def chunk(self, document: "DoclingDocument | None") -> list["Chunk"]:
         """Split a document into chunks with metadata.
 
         Args:

--- a/haiku_rag_slim/haiku/rag/chunkers/docling_local.py
+++ b/haiku_rag_slim/haiku/rag/chunkers/docling_local.py
@@ -177,7 +177,4 @@ class DoclingLocalChunker(DocumentChunker):
         Returns:
             List of Chunk containing content and structured metadata.
         """
-        if document is None:
-            return []
-
         return await asyncio.to_thread(self._chunk_sync, document)

--- a/haiku_rag_slim/haiku/rag/chunkers/docling_local.py
+++ b/haiku_rag_slim/haiku/rag/chunkers/docling_local.py
@@ -177,4 +177,7 @@ class DoclingLocalChunker(DocumentChunker):
         Returns:
             List of Chunk containing content and structured metadata.
         """
+        if document is None:
+            return []
+
         return await asyncio.to_thread(self._chunk_sync, document)

--- a/haiku_rag_slim/haiku/rag/chunkers/docling_local.py
+++ b/haiku_rag_slim/haiku/rag/chunkers/docling_local.py
@@ -162,7 +162,7 @@ class DoclingLocalChunker(DocumentChunker):
 
         return result
 
-    async def chunk(self, document: "DoclingDocument") -> list[Chunk]:
+    async def chunk(self, document: "DoclingDocument | None") -> list[Chunk]:
         """Split the document into chunks with metadata.
 
         Extracts structured metadata from each DocChunk including:

--- a/haiku_rag_slim/haiku/rag/chunkers/docling_local.py
+++ b/haiku_rag_slim/haiku/rag/chunkers/docling_local.py
@@ -1,3 +1,4 @@
+import asyncio
 from functools import cache
 from typing import TYPE_CHECKING, cast
 
@@ -105,24 +106,12 @@ class DoclingLocalChunker(DocumentChunker):
                 "Must be 'hybrid' or 'hierarchical'."
             )
 
-    async def chunk(self, document: "DoclingDocument") -> list[Chunk]:
-        """Split the document into chunks with metadata.
+    def _chunk_sync(self, document: "DoclingDocument") -> list[Chunk]:
+        """Synchronous chunking helper (CPU-bound, no I/O).
 
-        Extracts structured metadata from each DocChunk including:
-        - doc_item_refs: JSON pointer references to DocItems (e.g., "#/texts/5")
-        - headings: Section heading hierarchy
-        - labels: Semantic labels for each doc_item (e.g., "paragraph", "table")
-        - page_numbers: Page numbers where content appears
-
-        Args:
-            document: The DoclingDocument to be split into chunks.
-
-        Returns:
-            List of Chunk containing content and structured metadata.
+        Runs the underlying HybridChunker/HierarchicalChunker and extracts
+        structured metadata from each DocChunk.
         """
-        if document is None:
-            return []
-
         raw_chunks = list(self.chunker.chunk(document))
         result: list[Chunk] = []
 
@@ -172,3 +161,23 @@ class DoclingLocalChunker(DocumentChunker):
             )
 
         return result
+
+    async def chunk(self, document: "DoclingDocument") -> list[Chunk]:
+        """Split the document into chunks with metadata.
+
+        Extracts structured metadata from each DocChunk including:
+        - doc_item_refs: JSON pointer references to DocItems (e.g., "#/texts/5")
+        - headings: Section heading hierarchy
+        - labels: Semantic labels for each doc_item (e.g., "paragraph", "table")
+        - page_numbers: Page numbers where content appears
+
+        Args:
+            document: The DoclingDocument to be split into chunks.
+
+        Returns:
+            List of Chunk containing content and structured metadata.
+        """
+        if document is None:
+            return []
+
+        return await asyncio.to_thread(self._chunk_sync, document)

--- a/haiku_rag_slim/haiku/rag/chunkers/docling_serve.py
+++ b/haiku_rag_slim/haiku/rag/chunkers/docling_serve.py
@@ -129,7 +129,7 @@ class DoclingServeChunker(DocumentChunker):
 
         return result.get("chunks", [])
 
-    async def chunk(self, document: "DoclingDocument") -> list[Chunk]:
+    async def chunk(self, document: "DoclingDocument | None") -> list[Chunk]:
         """Split the document into chunks with metadata via docling-serve.
 
         Extracts structured metadata from the API response including:

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -56,6 +56,13 @@ async def test_local_chunker(qa_corpus: list[dict[str, str]]):
 
 
 @pytest.mark.asyncio
+async def test_local_chunker_none_document():
+    """Test DoclingLocalChunker returns empty list for None document."""
+    chunker = DoclingLocalChunker()
+    assert await chunker.chunk(None) == []
+
+
+@pytest.mark.asyncio
 async def test_local_chunker_runs_off_event_loop_thread():
     """Chunking is CPU-bound; verify it runs in a worker thread."""
     import threading

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -56,13 +56,6 @@ async def test_local_chunker(qa_corpus: list[dict[str, str]]):
 
 
 @pytest.mark.asyncio
-async def test_local_chunker_none_document():
-    """Test DoclingLocalChunker returns empty list for None document."""
-    chunker = DoclingLocalChunker()
-    assert await chunker.chunk(None) == []
-
-
-@pytest.mark.asyncio
 async def test_local_chunker_custom_config():
     """Test DoclingLocalChunker with custom configuration."""
     config = AppConfig()

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -59,6 +59,7 @@ async def test_local_chunker(qa_corpus: list[dict[str, str]]):
 async def test_local_chunker_runs_off_event_loop_thread():
     """Chunking is CPU-bound; verify it runs in a worker thread."""
     import threading
+    from unittest.mock import patch
 
     chunker = DoclingLocalChunker()
     event_loop_thread = threading.current_thread()
@@ -66,15 +67,15 @@ async def test_local_chunker_runs_off_event_loop_thread():
 
     original = chunker._chunk_sync
 
-    def recording_chunk_sync(document):
+    def recording_chunk_sync(self, document):
         called_from.append(threading.current_thread())
         return original(document)
 
-    chunker._chunk_sync = recording_chunk_sync
-
     converter = get_converter(Config)
     doc = await converter.convert_text("# Hello\n\nWorld", name="test.md")
-    await chunker.chunk(doc)
+
+    with patch.object(DoclingLocalChunker, "_chunk_sync", recording_chunk_sync):
+        await chunker.chunk(doc)
 
     assert called_from, "_chunk_sync was never called"
     assert called_from[0] is not event_loop_thread, (

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -56,6 +56,34 @@ async def test_local_chunker(qa_corpus: list[dict[str, str]]):
 
 
 @pytest.mark.asyncio
+async def test_local_chunker_runs_off_event_loop_thread():
+    """Chunking is CPU-bound; verify it runs in a worker thread."""
+    import threading
+
+    chunker = DoclingLocalChunker()
+    event_loop_thread = threading.current_thread()
+    called_from: list[threading.Thread] = []
+
+    original = chunker._chunk_sync
+
+    def recording_chunk_sync(document):
+        called_from.append(threading.current_thread())
+        return original(document)
+
+    chunker._chunk_sync = recording_chunk_sync
+
+    converter = get_converter(Config)
+    doc = await converter.convert_text("# Hello\n\nWorld", name="test.md")
+    await chunker.chunk(doc)
+
+    assert called_from, "_chunk_sync was never called"
+    assert called_from[0] is not event_loop_thread, (
+        "_chunk_sync ran on the event-loop thread; "
+        "it must be dispatched via asyncio.to_thread"
+    )
+
+
+@pytest.mark.asyncio
 async def test_local_chunker_custom_config():
     """Test DoclingLocalChunker with custom configuration."""
     config = AppConfig()

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -56,6 +56,13 @@ async def test_local_chunker(qa_corpus: list[dict[str, str]]):
 
 
 @pytest.mark.asyncio
+async def test_local_chunker_none_document():
+    """Test DoclingLocalChunker returns empty list for None document."""
+    chunker = DoclingLocalChunker()
+    assert await chunker.chunk(None) == []
+
+
+@pytest.mark.asyncio
 async def test_local_chunker_custom_config():
     """Test DoclingLocalChunker with custom configuration."""
     config = AppConfig()


### PR DESCRIPTION
## Summary

- Extracts the CPU-bound HybridChunker/HierarchicalChunker work into a sync helper `_chunk_sync` and wraps it with `asyncio.to_thread`
- Chunking performs tokenization and structural analysis proportional to document size — large documents (100+ pages) were blocking the event loop

## Test plan

- [ ] Existing test suite passes
- [ ] Ingester processes documents without errors under load

Fixes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)