### PR TITLE
Thread compress_docling_split in rebuild.py off the asyncio event loop

### DIFF
--- a/haiku_rag_slim/haiku/rag/client/rebuild.py
+++ b/haiku_rag_slim/haiku/rag/client/rebuild.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 from collections.abc import AsyncGenerator
@@ -618,6 +619,33 @@ async def _rebuild_rechunk(
         await _flush_rebuild_batch(client, pending_docs, pending_chunks)
 
 
+def _apply_descriptions_sync(docling_doc, doc, descriptions):
+    """Patch picture descriptions into the docling document and re-compress.
+
+    Updates only docling_document — set_docling would also overwrite
+    docling_pages by routing through compress_docling_split, which
+    extracts pages from the in-memory JSON and finds none (the pages
+    blob is stored separately and is not loaded by get_docling_document).
+    That would silently destroy page rasters for every doc with at
+    least one undescribed picture.
+    """
+    from docling_core.types.doc.document import DescriptionMetaField, PictureMeta
+    from haiku.rag.store.compression import compress_docling_split
+
+    for pic in docling_doc.pictures:
+        text = descriptions.get(pic.self_ref)
+        if not text:
+            continue
+        if pic.meta is None:
+            pic.meta = PictureMeta()
+        pic.meta.description = DescriptionMetaField(text=text)
+
+    structure_bytes, _ = compress_docling_split(docling_doc.model_dump_json())
+    doc.docling_document = structure_bytes
+    doc.docling_version = docling_doc.version
+    return len(descriptions)
+
+
 async def _patch_picture_descriptions(client: "HaikuRAG", doc: Document) -> int:
     """Run the VLM against pictures lacking a description, patch the docling
     blob in-place. Returns the number of newly described pictures.
@@ -660,33 +688,9 @@ async def _patch_picture_descriptions(client: "HaikuRAG", doc: Document) -> int:
     if not descriptions:
         return 0
 
-    # Patch the docling document in-place. PictureMeta + DescriptionMetaField
-    # are pydantic models; build them and assign.
-    from docling_core.types.doc.document import (
-        DescriptionMetaField,
-        PictureMeta,
+    return await asyncio.to_thread(
+        _apply_descriptions_sync, docling_doc, doc, descriptions
     )
-
-    for pic in docling_doc.pictures:
-        text = descriptions.get(pic.self_ref)
-        if not text:
-            continue
-        if pic.meta is None:
-            pic.meta = PictureMeta()
-        pic.meta.description = DescriptionMetaField(text=text)
-
-    # Update only docling_document — set_docling would also overwrite
-    # docling_pages by routing through compress_docling_split, which
-    # extracts pages from the in-memory JSON and finds none (the pages
-    # blob is stored separately and is not loaded by get_docling_document).
-    # That would silently destroy page rasters for every doc with at
-    # least one undescribed picture.
-    from haiku.rag.store.compression import compress_docling_split
-
-    structure_bytes, _ = compress_docling_split(docling_doc.model_dump_json())
-    doc.docling_document = structure_bytes
-    doc.docling_version = docling_doc.version
-    return len(descriptions)
 
 
 async def _rebuild_descriptions(

--- a/haiku_rag_slim/haiku/rag/client/rebuild.py
+++ b/haiku_rag_slim/haiku/rag/client/rebuild.py
@@ -630,6 +630,7 @@ def _apply_descriptions_sync(docling_doc, doc, descriptions):
     least one undescribed picture.
     """
     from docling_core.types.doc.document import DescriptionMetaField, PictureMeta
+
     from haiku.rag.store.compression import compress_docling_split
 
     for pic in docling_doc.pictures:

--- a/haiku_rag_slim/haiku/rag/client/rebuild.py
+++ b/haiku_rag_slim/haiku/rag/client/rebuild.py
@@ -18,6 +18,8 @@ from haiku.rag.store.models.document_item import extract_items
 from haiku.rag.store.repositories.settings import SettingsRepository
 
 if TYPE_CHECKING:
+    from docling_core.types.doc.document import DoclingDocument
+
     from haiku.rag.client import HaikuRAG, RebuildMode
 
 logger = logging.getLogger(__name__)
@@ -621,7 +623,9 @@ async def _rebuild_rechunk(
         await _flush_rebuild_batch(client, pending_docs, pending_chunks)
 
 
-def _apply_descriptions_sync(docling_doc, doc, descriptions):
+def _apply_descriptions_sync(
+    docling_doc: "DoclingDocument", doc: Document, descriptions: dict[str, str]
+) -> int:
     """Patch picture descriptions into the docling document and re-compress.
 
     Updates only docling_document — set_docling would also overwrite

--- a/haiku_rag_slim/haiku/rag/client/rebuild.py
+++ b/haiku_rag_slim/haiku/rag/client/rebuild.py
@@ -10,10 +10,10 @@ from lancedb.pydantic import LanceModel
 
 from haiku.rag.client.documents import check_source_accessible
 from haiku.rag.converters import get_converter
+from haiku.rag.store.compression import compress_docling_split
 from haiku.rag.store.engine import ChunkRecordBase
 from haiku.rag.store.models.chunk import Chunk
 from haiku.rag.store.models.document import Document
-from haiku.rag.store.compression import compress_docling_split
 from haiku.rag.store.models.document_item import extract_items
 from haiku.rag.store.repositories.settings import SettingsRepository
 

--- a/haiku_rag_slim/haiku/rag/client/rebuild.py
+++ b/haiku_rag_slim/haiku/rag/client/rebuild.py
@@ -5,6 +5,7 @@ from collections.abc import AsyncGenerator
 from datetime import datetime
 from typing import TYPE_CHECKING
 
+from docling_core.types.doc.document import DescriptionMetaField, PictureMeta
 from lancedb.pydantic import LanceModel
 
 from haiku.rag.client.documents import check_source_accessible
@@ -12,6 +13,7 @@ from haiku.rag.converters import get_converter
 from haiku.rag.store.engine import ChunkRecordBase
 from haiku.rag.store.models.chunk import Chunk
 from haiku.rag.store.models.document import Document
+from haiku.rag.store.compression import compress_docling_split
 from haiku.rag.store.models.document_item import extract_items
 from haiku.rag.store.repositories.settings import SettingsRepository
 
@@ -629,10 +631,6 @@ def _apply_descriptions_sync(docling_doc, doc, descriptions):
     That would silently destroy page rasters for every doc with at
     least one undescribed picture.
     """
-    from docling_core.types.doc.document import DescriptionMetaField, PictureMeta
-
-    from haiku.rag.store.compression import compress_docling_split
-
     for pic in docling_doc.pictures:
         text = descriptions.get(pic.self_ref)
         if not text:

--- a/tests/test_rebuild.py
+++ b/tests/test_rebuild.py
@@ -970,34 +970,6 @@ async def test_rebuild_descriptions_raises_when_blob_is_missing(
                 pass
 
 
-def test_apply_descriptions_sync_skips_pictures_without_descriptions():
-    """_apply_descriptions_sync skips pictures not in the descriptions dict."""
-    from unittest.mock import MagicMock
-
-    from haiku.rag.client.rebuild import _apply_descriptions_sync
-
-    pic_with = MagicMock()
-    pic_with.self_ref = "pic-1"
-    pic_with.meta = None
-
-    pic_without = MagicMock()
-    pic_without.self_ref = "pic-2"
-
-    docling_doc = MagicMock()
-    docling_doc.pictures = [pic_with, pic_without]
-    docling_doc.model_dump_json.return_value = "{}"
-    docling_doc.version = "1.0"
-
-    doc = MagicMock()
-
-    descriptions = {"pic-1": "A red square."}
-    n = _apply_descriptions_sync(docling_doc, doc, descriptions)
-
-    assert n == 1
-    assert pic_with.meta is not None
-    assert pic_with.meta.description.text == "A red square."
-
-
 async def _add_chunk(client: HaikuRAG, vector: list[float]) -> str:
     """Insert a chunk row directly, bypassing the embedder."""
     record = client.store.ChunkRecord(

--- a/tests/test_rebuild.py
+++ b/tests/test_rebuild.py
@@ -970,6 +970,34 @@ async def test_rebuild_descriptions_raises_when_blob_is_missing(
                 pass
 
 
+def test_apply_descriptions_sync_skips_pictures_without_descriptions():
+    """_apply_descriptions_sync skips pictures not in the descriptions dict."""
+    from unittest.mock import MagicMock
+
+    from haiku.rag.client.rebuild import _apply_descriptions_sync
+
+    pic_with = MagicMock()
+    pic_with.self_ref = "pic-1"
+    pic_with.meta = None
+
+    pic_without = MagicMock()
+    pic_without.self_ref = "pic-2"
+
+    docling_doc = MagicMock()
+    docling_doc.pictures = [pic_with, pic_without]
+    docling_doc.model_dump_json.return_value = "{}"
+    docling_doc.version = "1.0"
+
+    doc = MagicMock()
+
+    descriptions = {"pic-1": "A red square."}
+    n = _apply_descriptions_sync(docling_doc, doc, descriptions)
+
+    assert n == 1
+    assert pic_with.meta is not None
+    assert pic_with.meta.description.text == "A red square."
+
+
 async def _add_chunk(client: HaikuRAG, vector: list[float]) -> str:
     """Insert a chunk row directly, bypassing the embedder."""
     record = client.store.ChunkRecord(


### PR DESCRIPTION
## Summary

- Extracts pydantic serialization (`model_dump_json()`) and zstd compression (`compress_docling_split()`) into a sync helper `_apply_descriptions_sync` and wraps it with `asyncio.to_thread`
- Picture description rebuilds on large documents with embedded images were blocking the event loop

## Test plan

- [ ] Existing test suite passes
- [ ] `rebuild --descriptions` completes without errors

Fixes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)