### PR TITLE
change breakers to be per-instance

### DIFF
--- a/haiku_rag_slim/haiku/rag/chunkers/docling_serve.py
+++ b/haiku_rag_slim/haiku/rag/chunkers/docling_serve.py
@@ -56,9 +56,11 @@ class DoclingServeChunker(DocumentChunker):
 
     def __init__(self, config: AppConfig = Config):
         self.config = config
+        ds = config.providers.docling_serve
         self.client = DoclingServeClient(
-            base_urls=config.providers.docling_serve.base_urls,
-            api_key=config.providers.docling_serve.api_key,
+            base_urls=ds.base_urls,
+            api_key=ds.api_key,
+            breaker_config=ds.circuit_breaker,
         )
         self.chunker_type = config.processing.chunker_type
 

--- a/haiku_rag_slim/haiku/rag/circuit_breaker.py
+++ b/haiku_rag_slim/haiku/rag/circuit_breaker.py
@@ -5,7 +5,11 @@ from haiku.rag.config import CircuitBreakerConfig
 
 
 class CircuitBreaker:
-    """Three-state breaker over discover() failures.
+    """Three-state circuit breaker (closed / open with cooldown).
+
+    Shared by the ingester's per-source discover() breaker and the
+    docling-serve per-instance breaker — lives here, below both
+    ``providers`` and ``ingester``, so neither has to depend on the other.
 
     - closed: failures are counted; threshold flips to open.
     - open: probes are blocked until cooldown elapses, then a single probe

--- a/haiku_rag_slim/haiku/rag/config/models.py
+++ b/haiku_rag_slim/haiku/rag/config/models.py
@@ -218,6 +218,20 @@ class OllamaConfig(BaseModel):
     )
 
 
+class CircuitBreakerConfig(BaseModel):
+    """Three-state breaker (closed -> open -> probe) over consecutive failures.
+    Used by the ingester's per-source discover() breaker and the docling-serve
+    per-instance breaker."""
+
+    failure_threshold: int = Field(
+        default=5, description="Consecutive failures before the breaker opens."
+    )
+    cooldown_s: float = Field(
+        default=600.0,
+        description="How long the breaker stays open before allowing a probe.",
+    )
+
+
 class DoclingServeConfig(BaseModel):
     """docling-serve endpoints. Accepts a single URL or a list — when a list
     is given, the client round-robins jobs across the URLs. Each job's
@@ -227,6 +241,14 @@ class DoclingServeConfig(BaseModel):
 
     base_url: str | list[str] = "http://localhost:5001"
     api_key: str = ""
+    circuit_breaker: CircuitBreakerConfig = Field(
+        default_factory=lambda: CircuitBreakerConfig(
+            failure_threshold=3, cooldown_s=30.0
+        ),
+        description="Per-instance circuit breaker: skip an instance after this "
+        "many consecutive failures for this cooldown. Defaults are tuned faster "
+        "than the discover breaker since instances restart quickly.",
+    )
 
     @property
     def base_urls(self) -> list[str]:
@@ -293,19 +315,6 @@ class RetryPolicyConfig(BaseModel):
     base_delay_s: float = 2.0
     max_delay_s: float = 300.0
     jitter: float = Field(default=0.25, ge=0.0, le=1.0)
-
-
-class CircuitBreakerConfig(BaseModel):
-    """Per-source breaker over discover() failures. Stops the ingester from
-    hammering a source that's persistently failing."""
-
-    failure_threshold: int = Field(
-        default=5, description="Consecutive failures before the breaker opens."
-    )
-    cooldown_s: float = Field(
-        default=600.0,
-        description="How long the breaker stays open before allowing a probe.",
-    )
 
 
 class WorkerConfig(BaseModel):

--- a/haiku_rag_slim/haiku/rag/converters/docling_serve.py
+++ b/haiku_rag_slim/haiku/rag/converters/docling_serve.py
@@ -59,9 +59,11 @@ class DoclingServeConverter(DocumentConverter):
             config: Application configuration containing docling-serve settings.
         """
         self.config = config
+        ds = config.providers.docling_serve
         self.client = DoclingServeClient(
-            base_urls=config.providers.docling_serve.base_urls,
-            api_key=config.providers.docling_serve.api_key,
+            base_urls=ds.base_urls,
+            api_key=ds.api_key,
+            breaker_config=ds.circuit_breaker,
         )
 
     @property

--- a/haiku_rag_slim/haiku/rag/ingester/pollers/__init__.py
+++ b/haiku_rag_slim/haiku/rag/ingester/pollers/__init__.py
@@ -1,4 +1,4 @@
-from haiku.rag.ingester.pollers.circuit_breaker import CircuitBreaker
+from haiku.rag.circuit_breaker import CircuitBreaker
 from haiku.rag.ingester.pollers.factory import build_source
 from haiku.rag.ingester.pollers.fs import FSPoller
 from haiku.rag.ingester.pollers.manager import PollerManager

--- a/haiku_rag_slim/haiku/rag/ingester/pollers/base.py
+++ b/haiku_rag_slim/haiku/rag/ingester/pollers/base.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime
 
 from haiku.rag.config import SourceConfig
 from haiku.rag.ingester.batch import BatchChange, BatchSourceSummary
-from haiku.rag.ingester.pollers.circuit_breaker import CircuitBreaker
+from haiku.rag.circuit_breaker import CircuitBreaker
 from haiku.rag.ingester.queue.models import JobOp, SyncRow
 from haiku.rag.ingester.queue.repository import JobRepo, SyncStateRepo
 from haiku.rag.ingester.sources.base import (

--- a/haiku_rag_slim/haiku/rag/ingester/pollers/fs.py
+++ b/haiku_rag_slim/haiku/rag/ingester/pollers/fs.py
@@ -12,7 +12,7 @@ from haiku.rag.telemetry import logfire
 
 if TYPE_CHECKING:
     from haiku.rag.config import FSSourceConfig
-    from haiku.rag.ingester.pollers.circuit_breaker import CircuitBreaker
+    from haiku.rag.circuit_breaker import CircuitBreaker
     from haiku.rag.ingester.sources.fs import FSSource
 
 logger = logging.getLogger(__name__)

--- a/haiku_rag_slim/haiku/rag/ingester/pollers/manager.py
+++ b/haiku_rag_slim/haiku/rag/ingester/pollers/manager.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from haiku.rag.config import FSSourceConfig, SourceConfig
 from haiku.rag.ingester.batch import BatchManifest
 from haiku.rag.ingester.pollers.base import BasePoller
-from haiku.rag.ingester.pollers.circuit_breaker import CircuitBreaker
+from haiku.rag.circuit_breaker import CircuitBreaker
 from haiku.rag.ingester.pollers.factory import build_source
 from haiku.rag.ingester.pollers.fs import FSPoller
 from haiku.rag.ingester.pollers.periodic import PeriodicPoller

--- a/haiku_rag_slim/haiku/rag/ingester/pollers/periodic.py
+++ b/haiku_rag_slim/haiku/rag/ingester/pollers/periodic.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 from haiku.rag.ingester.pollers.base import BasePoller
 
 if TYPE_CHECKING:
-    from haiku.rag.ingester.pollers.circuit_breaker import CircuitBreaker
+    from haiku.rag.circuit_breaker import CircuitBreaker
 
 
 class PeriodicPoller(BasePoller):

--- a/haiku_rag_slim/haiku/rag/ingester/workers/pool.py
+++ b/haiku_rag_slim/haiku/rag/ingester/workers/pool.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 from haiku.rag.config import CircuitBreakerConfig
 from haiku.rag.ingester.exceptions import PermanentError, TransientError
-from haiku.rag.ingester.pollers.circuit_breaker import CircuitBreaker
+from haiku.rag.circuit_breaker import CircuitBreaker
 from haiku.rag.ingester.queue.models import Job, JobOp
 from haiku.rag.ingester.queue.repository import JobRepo, SyncStateRepo
 from haiku.rag.ingester.workers.pipeline import run_job

--- a/haiku_rag_slim/haiku/rag/providers/docling_serve.py
+++ b/haiku_rag_slim/haiku/rag/providers/docling_serve.py
@@ -2,9 +2,70 @@
 
 import asyncio
 import itertools
+import logging
+import time
+from collections.abc import Callable
 from typing import Any
 
 import httpx
+
+logger = logging.getLogger(__name__)
+
+# HTTP statuses that count against an instance's health: 408/429 are transient
+# overload, 5xx is a crashed/restarting worker (the OOM-leak failure mode).
+_UNHEALTHY_STATUS = frozenset({408, 429})
+
+
+def _is_instance_failure(exc: BaseException) -> bool:
+    """Whether a failure reflects an unhealthy docling-serve instance and should
+    count against its circuit breaker: transport errors (connection reset /
+    timeout — a crashed or unresponsive instance) and 5xx/overload. Other 4xx
+    are the caller's fault and the task-level ``ValueError`` from
+    ``_submit_and_wait`` is a document problem — neither reflects instance
+    health, so they don't trip the breaker."""
+    if isinstance(exc, httpx.HTTPStatusError):
+        status = exc.response.status_code
+        return status in _UNHEALTHY_STATUS or status >= 500
+    return isinstance(exc, httpx.TransportError)
+
+
+class _InstanceBreaker:
+    """Per-instance circuit breaker (closed / open with cooldown).
+
+    Self-contained so the provider layer doesn't depend on the ingester
+    package. ``is_open`` auto-probes after the cooldown elapses: a single
+    request is allowed through, and its success closes the breaker while another
+    failure re-opens it.
+    """
+
+    def __init__(
+        self,
+        failure_threshold: int,
+        cooldown_s: float,
+        now_fn: Callable[[], float],
+    ):
+        self._threshold = failure_threshold
+        self._cooldown_s = cooldown_s
+        self._now = now_fn
+        self._consecutive_failures = 0
+        self._opened_at: float | None = None
+
+    @property
+    def is_open(self) -> bool:
+        if self._opened_at is None:
+            return False
+        # Cooldown elapsed → let the next request probe the instance.
+        return self._now() - self._opened_at < self._cooldown_s
+
+    def record_success(self) -> None:
+        self._consecutive_failures = 0
+        self._opened_at = None
+
+    def record_failure(self) -> None:
+        self._consecutive_failures += 1
+        if self._consecutive_failures >= self._threshold:
+            self._opened_at = self._now()
+
 
 # Process-global registry of round-robin rotators over docling-serve
 # instances, keyed by the sorted tuple of base URLs. Clients are constructed
@@ -13,6 +74,13 @@ import httpx
 # pointing at the same instance set share one rotator; clients with
 # different sets get independent rotators.
 _instance_rotators: dict[tuple[str, ...], "itertools.cycle[str]"] = {}
+
+# Process-global per-instance breakers, keyed by base URL. Like the rotators,
+# these must outlive the per-job client so an instance that crashed stays
+# skipped across subsequent jobs until its cooldown elapses. The first client
+# to touch a URL fixes that breaker's threshold/cooldown/clock; in practice all
+# clients share one config (the docling-serve provider config).
+_instance_breakers: dict[str, "_InstanceBreaker"] = {}
 
 
 class DoclingServeClient:
@@ -31,6 +99,9 @@ class DoclingServeClient:
         api_key: str | None = None,
         timeout: float = 300,
         transport: httpx.AsyncBaseTransport | None = None,
+        breaker_failure_threshold: int = 3,
+        breaker_cooldown_s: float = 30.0,
+        now_fn: Callable[[], float] = time.monotonic,
     ):
         urls = [base_urls] if isinstance(base_urls, str) else list(base_urls)
         if not urls:
@@ -40,6 +111,9 @@ class DoclingServeClient:
         self.timeout = timeout
         # transport is for testing — production callers leave it None.
         self._transport = transport
+        self._breaker_failure_threshold = breaker_failure_threshold
+        self._breaker_cooldown_s = breaker_cooldown_s
+        self._now = now_fn
         # setdefault is atomic under the GIL — concurrent constructors with
         # the same instance set will end up sharing one rotator.
         key = tuple(sorted(self.base_urls))
@@ -56,8 +130,49 @@ class DoclingServeClient:
         callers should let `_pick_url` round-robin per request."""
         return self.base_urls[0]
 
+    def _breaker_for(self, url: str) -> _InstanceBreaker:
+        breaker = _instance_breakers.get(url)
+        if breaker is None:
+            breaker = _InstanceBreaker(
+                self._breaker_failure_threshold,
+                self._breaker_cooldown_s,
+                self._now,
+            )
+            _instance_breakers[url] = breaker
+        return breaker
+
     def _pick_url(self) -> str:
-        return next(self._instance_rotator)
+        """Next instance in the round-robin, skipping any whose circuit breaker
+        is open (an instance that recently crashed / overloaded). Falls back to
+        the first instance seen when every breaker is open — a single-instance
+        fleet, or a fully-down one, still gets a probe rather than no attempt."""
+        fallback: str | None = None
+        for _ in range(len(self.base_urls)):
+            url = next(self._instance_rotator)
+            if fallback is None:
+                fallback = url
+            if not self._breaker_for(url).is_open:
+                return url
+        assert fallback is not None  # base_urls is non-empty (checked in __init__)
+        return fallback
+
+    def _record_outcome(self, base_url: str, exc: BaseException) -> None:
+        """Record a failed request against the instance's breaker, but only when
+        the failure reflects instance health (transport / 5xx). 4xx and
+        task-level errors are left alone — they aren't the instance's fault."""
+        if not _is_instance_failure(exc):
+            return
+        breaker = self._breaker_for(base_url)
+        was_open = breaker.is_open
+        breaker.record_failure()
+        if not was_open and breaker.is_open:
+            logger.warning(
+                "docling-serve instance %s breaker opened after %d consecutive "
+                "failure(s); skipping it for %.0fs",
+                base_url,
+                self._breaker_failure_threshold,
+                self._breaker_cooldown_s,
+            )
 
     def _get_headers(self) -> dict[str, str]:
         """Get headers for API requests."""
@@ -122,18 +237,26 @@ class DoclingServeClient:
         etc.) propagate so the ingester's pipeline classifier can route
         4xx → PermanentError and 5xx/network → TransientError. ValueError
         is raised by `_submit_and_wait` when docling-serve reports a task
-        failure or returns no task_id.
+        failure or returns no task_id. Instance-health failures (transport /
+        5xx) trip the picked instance's circuit breaker so later requests skip
+        it while it recovers.
         """
         headers = self._get_headers()
         base_url = self._pick_url()
-        async with self._httpx_client() as client:
-            task_id = await self._submit_and_wait(
-                client, base_url, endpoint, files, data, headers, name
-            )
-            result_url = f"{base_url}/v1/result/{task_id}"
-            result_response = await client.get(result_url, headers=headers)
-            result_response.raise_for_status()
-            return result_response.json()
+        try:
+            async with self._httpx_client() as client:
+                task_id = await self._submit_and_wait(
+                    client, base_url, endpoint, files, data, headers, name
+                )
+                result_url = f"{base_url}/v1/result/{task_id}"
+                result_response = await client.get(result_url, headers=headers)
+                result_response.raise_for_status()
+                result = result_response.json()
+        except Exception as exc:
+            self._record_outcome(base_url, exc)
+            raise
+        self._breaker_for(base_url).record_success()
+        return result
 
     async def submit_and_poll_zip(
         self,
@@ -147,15 +270,22 @@ class DoclingServeClient:
         Used when the caller requested ``target_type=zip`` (e.g. to retrieve
         picture image bytes that docling-serve only emits as referenced files
         bundled into a zip archive). The submit/poll flow is identical to
-        ``submit_and_poll``; only the result-fetching step differs.
+        ``submit_and_poll`` (including circuit-breaker bookkeeping); only the
+        result-fetching step differs.
         """
         headers = self._get_headers()
         base_url = self._pick_url()
-        async with self._httpx_client() as client:
-            task_id = await self._submit_and_wait(
-                client, base_url, endpoint, files, data, headers, name
-            )
-            result_url = f"{base_url}/v1/result/{task_id}"
-            result_response = await client.get(result_url, headers=headers)
-            result_response.raise_for_status()
-            return result_response.content
+        try:
+            async with self._httpx_client() as client:
+                task_id = await self._submit_and_wait(
+                    client, base_url, endpoint, files, data, headers, name
+                )
+                result_url = f"{base_url}/v1/result/{task_id}"
+                result_response = await client.get(result_url, headers=headers)
+                result_response.raise_for_status()
+                result = result_response.content
+        except Exception as exc:
+            self._record_outcome(base_url, exc)
+            raise
+        self._breaker_for(base_url).record_success()
+        return result

--- a/haiku_rag_slim/haiku/rag/providers/docling_serve.py
+++ b/haiku_rag_slim/haiku/rag/providers/docling_serve.py
@@ -9,6 +9,9 @@ from typing import Any
 
 import httpx
 
+from haiku.rag.circuit_breaker import CircuitBreaker
+from haiku.rag.config import CircuitBreakerConfig
+
 logger = logging.getLogger(__name__)
 
 # HTTP statuses that count against an instance's health: 408/429 are transient
@@ -29,44 +32,6 @@ def _is_instance_failure(exc: BaseException) -> bool:
     return isinstance(exc, httpx.TransportError)
 
 
-class _InstanceBreaker:
-    """Per-instance circuit breaker (closed / open with cooldown).
-
-    Self-contained so the provider layer doesn't depend on the ingester
-    package. ``is_open`` auto-probes after the cooldown elapses: a single
-    request is allowed through, and its success closes the breaker while another
-    failure re-opens it.
-    """
-
-    def __init__(
-        self,
-        failure_threshold: int,
-        cooldown_s: float,
-        now_fn: Callable[[], float],
-    ):
-        self._threshold = failure_threshold
-        self._cooldown_s = cooldown_s
-        self._now = now_fn
-        self._consecutive_failures = 0
-        self._opened_at: float | None = None
-
-    @property
-    def is_open(self) -> bool:
-        if self._opened_at is None:
-            return False
-        # Cooldown elapsed → let the next request probe the instance.
-        return self._now() - self._opened_at < self._cooldown_s
-
-    def record_success(self) -> None:
-        self._consecutive_failures = 0
-        self._opened_at = None
-
-    def record_failure(self) -> None:
-        self._consecutive_failures += 1
-        if self._consecutive_failures >= self._threshold:
-            self._opened_at = self._now()
-
-
 # Process-global registry of round-robin rotators over docling-serve
 # instances, keyed by the sorted tuple of base URLs. Clients are constructed
 # per-job by `get_converter` / `get_chunker`, so the rotation cursor has to
@@ -80,7 +45,7 @@ _instance_rotators: dict[tuple[str, ...], "itertools.cycle[str]"] = {}
 # skipped across subsequent jobs until its cooldown elapses. The first client
 # to touch a URL fixes that breaker's threshold/cooldown/clock; in practice all
 # clients share one config (the docling-serve provider config).
-_instance_breakers: dict[str, "_InstanceBreaker"] = {}
+_instance_breakers: dict[str, "CircuitBreaker"] = {}
 
 
 class DoclingServeClient:
@@ -99,8 +64,7 @@ class DoclingServeClient:
         api_key: str | None = None,
         timeout: float = 300,
         transport: httpx.AsyncBaseTransport | None = None,
-        breaker_failure_threshold: int = 3,
-        breaker_cooldown_s: float = 30.0,
+        breaker_config: CircuitBreakerConfig | None = None,
         now_fn: Callable[[], float] = time.monotonic,
     ):
         urls = [base_urls] if isinstance(base_urls, str) else list(base_urls)
@@ -111,8 +75,12 @@ class DoclingServeClient:
         self.timeout = timeout
         # transport is for testing — production callers leave it None.
         self._transport = transport
-        self._breaker_failure_threshold = breaker_failure_threshold
-        self._breaker_cooldown_s = breaker_cooldown_s
+        # Per-instance breaker config; defaults are tuned faster than the
+        # ingester's discover breaker since docling-serve instances restart
+        # quickly. Overridden from DoclingServeConfig.circuit_breaker.
+        self._breaker_config = breaker_config or CircuitBreakerConfig(
+            failure_threshold=3, cooldown_s=30.0
+        )
         self._now = now_fn
         # setdefault is atomic under the GIL — concurrent constructors with
         # the same instance set will end up sharing one rotator.
@@ -130,31 +98,27 @@ class DoclingServeClient:
         callers should let `_pick_url` round-robin per request."""
         return self.base_urls[0]
 
-    def _breaker_for(self, url: str) -> _InstanceBreaker:
+    def _breaker_for(self, url: str) -> CircuitBreaker:
         breaker = _instance_breakers.get(url)
         if breaker is None:
-            breaker = _InstanceBreaker(
-                self._breaker_failure_threshold,
-                self._breaker_cooldown_s,
-                self._now,
-            )
+            breaker = CircuitBreaker(self._breaker_config, now_fn=self._now)
             _instance_breakers[url] = breaker
         return breaker
 
     def _pick_url(self) -> str:
         """Next instance in the round-robin, skipping any whose circuit breaker
-        is open (an instance that recently crashed / overloaded). Falls back to
-        the first instance seen when every breaker is open — a single-instance
-        fleet, or a fully-down one, still gets a probe rather than no attempt."""
-        fallback: str | None = None
+        is open (an instance that recently crashed / overloaded). When every
+        breaker is open — a single-instance fleet, or a fully-down one — probe
+        one anyway rather than failing with nothing to pick."""
         for _ in range(len(self.base_urls)):
             url = next(self._instance_rotator)
-            if fallback is None:
-                fallback = url
             if not self._breaker_for(url).is_open:
                 return url
-        assert fallback is not None  # base_urls is non-empty (checked in __init__)
-        return fallback
+        # All breakers open. Take one more step (the loop consumed a full
+        # rotation, landing the cursor back at the start) so consecutive
+        # all-open calls rotate across instances instead of pinning the first
+        # one — an all-429 overload shouldn't pile every retry on one node.
+        return next(self._instance_rotator)
 
     def _record_outcome(self, base_url: str, exc: BaseException) -> None:
         """Record a failed request against the instance's breaker, but only when
@@ -170,8 +134,8 @@ class DoclingServeClient:
                 "docling-serve instance %s breaker opened after %d consecutive "
                 "failure(s); skipping it for %.0fs",
                 base_url,
-                self._breaker_failure_threshold,
-                self._breaker_cooldown_s,
+                self._breaker_config.failure_threshold,
+                self._breaker_config.cooldown_s,
             )
 
     def _get_headers(self) -> dict[str, str]:

--- a/tests/ingester/test_circuit_breaker.py
+++ b/tests/ingester/test_circuit_breaker.py
@@ -1,5 +1,5 @@
 from haiku.rag.config import CircuitBreakerConfig
-from haiku.rag.ingester.pollers.circuit_breaker import CircuitBreaker
+from haiku.rag.circuit_breaker import CircuitBreaker
 
 
 class _Clock:

--- a/tests/ingester/test_pollers.py
+++ b/tests/ingester/test_pollers.py
@@ -11,7 +11,7 @@ from haiku.rag.config import (
     S3SourceConfig,
     WebDAVSourceConfig,
 )
-from haiku.rag.ingester.pollers.circuit_breaker import CircuitBreaker
+from haiku.rag.circuit_breaker import CircuitBreaker
 from haiku.rag.ingester.pollers.manager import PollerManager
 from haiku.rag.ingester.pollers.periodic import PeriodicPoller
 from haiku.rag.ingester.queue.models import JobOp, JobStatus

--- a/tests/test_docling_serve_client.py
+++ b/tests/test_docling_serve_client.py
@@ -234,6 +234,49 @@ async def test_4xx_does_not_trip_breaker():
 
 
 @pytest.mark.asyncio
+async def test_pick_url_falls_back_when_all_breakers_open():
+    """When every instance's breaker is open (here a single-instance fleet that
+    just failed), _pick_url still returns one so the request can probe it rather
+    than failing with nothing to pick."""
+    lone = "http://lone-w:5001"
+    transport, _ = _health_transport({"lone-w"}, "t", {"ok": True})
+    client = DoclingServeClient(
+        base_urls=[lone],
+        transport=transport,
+        breaker_failure_threshold=1,
+    )
+
+    await _poll(client)  # fails → breaker opens (threshold=1)
+    assert client._breaker_for(lone).is_open
+
+    # The only instance's breaker is open; _pick_url falls back to it.
+    assert client._pick_url() == lone
+
+
+@pytest.mark.asyncio
+async def test_zip_records_instance_failure():
+    """submit_and_poll_zip records a crashed instance against its breaker, the
+    same as submit_and_poll — covers the zip method's failure path."""
+    z = "http://zdown-v:5001"
+    transport, _ = _health_transport({"zdown-v"}, "t", {})
+    client = DoclingServeClient(
+        base_urls=[z],
+        transport=transport,
+        breaker_failure_threshold=1,
+    )
+
+    with pytest.raises(httpx.ConnectError):
+        await client.submit_and_poll_zip(
+            endpoint="/v1/convert/file/async",
+            files={"file": ("x.md", b"x", "text/markdown")},
+            data={},
+        )
+
+    # The failure tripped the (threshold=1) breaker via _record_outcome.
+    assert client._breaker_for(z).is_open
+
+
+@pytest.mark.asyncio
 async def test_zip_endpoint_uses_round_robin_too():
     transport, seen = _scripted_transport(
         {

--- a/tests/test_docling_serve_client.py
+++ b/tests/test_docling_serve_client.py
@@ -110,6 +110,129 @@ def test_round_robin_shared_across_fresh_clients():
     assert picks == [urls[0], urls[1], urls[2], urls[0]]
 
 
+def _health_transport(
+    down: set[str], task_id: str, result: dict
+) -> tuple[httpx.MockTransport, list[str]]:
+    """MockTransport where requests to a host in the mutable ``down`` set raise
+    ConnectError (a crashed instance); other hosts serve a normal trio. The
+    caller can mutate ``down`` mid-test to flip an instance's health. Records
+    every host attempted."""
+    seen: list[str] = []
+    routes = _success_routes(task_id, result)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.url.host)
+        if request.url.host in down:
+            raise httpx.ConnectError("connection refused", request=request)
+        return routes.get(request.url.path, httpx.Response(404))
+
+    return httpx.MockTransport(handler), seen
+
+
+async def _poll(client: DoclingServeClient) -> None:
+    """Issue one submit_and_poll, swallowing the transport error raised when the
+    picked instance is down (this baseline has no in-request failover yet)."""
+    try:
+        await client.submit_and_poll(
+            endpoint="/v1/convert/file/async",
+            files={"file": ("x.md", b"x", "text/markdown")},
+            data={},
+        )
+    except httpx.TransportError:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_open_breaker_skips_crashed_instance():
+    """Once an instance has failed enough to open its breaker, _pick_url skips
+    it — later requests route straight to a healthy instance without even
+    attempting the dead one."""
+    down = {"crash-x"}
+    transport, seen = _health_transport(down, "t", {"ok": True})
+    client = DoclingServeClient(
+        base_urls=["http://crash-x:5001", "http://live-x:5001"],
+        transport=transport,
+        breaker_failure_threshold=2,
+    )
+
+    await _poll(client)  # picks crash-x → fail (failures=1)
+    await _poll(client)  # picks live-x → ok
+    await _poll(client)  # picks crash-x → fail (failures=2 → breaker opens)
+
+    assert client._breaker_for("http://crash-x:5001").is_open
+
+    seen.clear()
+    await _poll(client)
+    await _poll(client)
+    assert "crash-x" not in seen
+    assert set(seen) == {"live-x"}
+
+
+@pytest.mark.asyncio
+async def test_breaker_recovers_after_cooldown():
+    """An open breaker auto-probes after its cooldown; once the instance is
+    healthy again a successful request closes the breaker."""
+    clock = [1000.0]
+    down = {"flip-y"}
+    transport, seen = _health_transport(down, "t", {"ok": True})
+    flip = "http://flip-y:5001"
+    client = DoclingServeClient(
+        base_urls=[flip, "http://spare-y:5001"],
+        transport=transport,
+        breaker_failure_threshold=2,
+        breaker_cooldown_s=30.0,
+        now_fn=lambda: clock[0],
+    )
+
+    await _poll(client)  # flip-y → fail (1)
+    await _poll(client)  # spare-y → ok
+    await _poll(client)  # flip-y → fail (2 → open)
+    assert client._breaker_for(flip).is_open
+
+    # Instance recovers, but within the cooldown it's still treated as open.
+    down.clear()
+    assert client._breaker_for(flip).is_open
+
+    # After the cooldown the breaker allows a probe again.
+    clock[0] += 31.0
+    assert not client._breaker_for(flip).is_open
+
+    # Traffic can return to flip-y and success closes the breaker for good.
+    seen.clear()
+    for _ in range(2):
+        await _poll(client)
+    assert "flip-y" in seen
+    assert not client._breaker_for(flip).is_open
+
+
+@pytest.mark.asyncio
+async def test_4xx_does_not_trip_breaker():
+    """A 4xx is the caller's fault — it must not count against instance health,
+    even with a 1-failure threshold."""
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.url.host)
+        return httpx.Response(400, json={"detail": "bad request"})
+
+    bad = "http://bad-z:5001"
+    client = DoclingServeClient(
+        base_urls=[bad],
+        transport=httpx.MockTransport(handler),
+        breaker_failure_threshold=1,
+    )
+
+    for _ in range(3):
+        with pytest.raises(httpx.HTTPStatusError):
+            await client.submit_and_poll(
+                endpoint="/v1/convert/file/async",
+                files={"file": ("x.md", b"x", "text/markdown")},
+                data={},
+            )
+
+    assert not client._breaker_for(bad).is_open
+
+
 @pytest.mark.asyncio
 async def test_zip_endpoint_uses_round_robin_too():
     transport, seen = _scripted_transport(

--- a/tests/test_docling_serve_client.py
+++ b/tests/test_docling_serve_client.py
@@ -9,6 +9,7 @@ resume mid-rotation, breaking specific-order assertions.
 import httpx
 import pytest
 
+from haiku.rag.config import CircuitBreakerConfig
 from haiku.rag.providers.docling_serve import DoclingServeClient
 
 
@@ -152,7 +153,7 @@ async def test_open_breaker_skips_crashed_instance():
     client = DoclingServeClient(
         base_urls=["http://crash-x:5001", "http://live-x:5001"],
         transport=transport,
-        breaker_failure_threshold=2,
+        breaker_config=CircuitBreakerConfig(failure_threshold=2, cooldown_s=30.0),
     )
 
     await _poll(client)  # picks crash-x → fail (failures=1)
@@ -179,8 +180,7 @@ async def test_breaker_recovers_after_cooldown():
     client = DoclingServeClient(
         base_urls=[flip, "http://spare-y:5001"],
         transport=transport,
-        breaker_failure_threshold=2,
-        breaker_cooldown_s=30.0,
+        breaker_config=CircuitBreakerConfig(failure_threshold=2, cooldown_s=30.0),
         now_fn=lambda: clock[0],
     )
 
@@ -219,7 +219,7 @@ async def test_4xx_does_not_trip_breaker():
     client = DoclingServeClient(
         base_urls=[bad],
         transport=httpx.MockTransport(handler),
-        breaker_failure_threshold=1,
+        breaker_config=CircuitBreakerConfig(failure_threshold=1, cooldown_s=30.0),
     )
 
     for _ in range(3):
@@ -243,7 +243,7 @@ async def test_pick_url_falls_back_when_all_breakers_open():
     client = DoclingServeClient(
         base_urls=[lone],
         transport=transport,
-        breaker_failure_threshold=1,
+        breaker_config=CircuitBreakerConfig(failure_threshold=1, cooldown_s=30.0),
     )
 
     await _poll(client)  # fails → breaker opens (threshold=1)
@@ -251,6 +251,54 @@ async def test_pick_url_falls_back_when_all_breakers_open():
 
     # The only instance's breaker is open; _pick_url falls back to it.
     assert client._pick_url() == lone
+
+
+@pytest.mark.asyncio
+async def test_all_open_breakers_rotate_instead_of_pinning_one():
+    """When every breaker is open, successive picks must rotate across the
+    fleet rather than pinning the first instance — an all-429 overload
+    shouldn't pile every retry on one node."""
+    urls = [
+        "http://allopen-a:5001",
+        "http://allopen-b:5001",
+        "http://allopen-c:5001",
+    ]
+    transport, _ = _health_transport(
+        {"allopen-a", "allopen-b", "allopen-c"}, "t", {"ok": True}
+    )
+    client = DoclingServeClient(
+        base_urls=urls,
+        transport=transport,
+        breaker_config=CircuitBreakerConfig(failure_threshold=1, cooldown_s=30.0),
+    )
+
+    # One failure each opens all three breakers: each _poll picks the next
+    # still-closed instance, fails, and opens it.
+    for _ in range(3):
+        await _poll(client)
+    assert all(client._breaker_for(u).is_open for u in urls)
+
+    picks = [client._pick_url() for _ in range(6)]
+    # All-open fallback rotates a → b → c → a → b → c, not the same URL six times.
+    assert picks == urls + urls
+
+
+def test_config_breaker_reaches_client():
+    """The breaker config set on DoclingServeConfig must reach the client via
+    get_converter / get_chunker (previously hardcoded constructor defaults)."""
+    from haiku.rag.chunkers.docling_serve import DoclingServeChunker
+    from haiku.rag.config import AppConfig
+    from haiku.rag.converters.docling_serve import DoclingServeConverter
+
+    config = AppConfig()
+    config.providers.docling_serve.base_url = "http://cfg-brk:5001"
+    config.providers.docling_serve.circuit_breaker = CircuitBreakerConfig(
+        failure_threshold=9, cooldown_s=123.0
+    )
+
+    for component in (DoclingServeConverter(config), DoclingServeChunker(config)):
+        assert component.client._breaker_config.failure_threshold == 9
+        assert component.client._breaker_config.cooldown_s == 123.0
 
 
 @pytest.mark.asyncio
@@ -262,7 +310,7 @@ async def test_zip_records_instance_failure():
     client = DoclingServeClient(
         base_urls=[z],
         transport=transport,
-        breaker_failure_threshold=1,
+        breaker_config=CircuitBreakerConfig(failure_threshold=1, cooldown_s=30.0),
     )
 
     with pytest.raises(httpx.ConnectError):


### PR DESCRIPTION
# resilience: per-instance circuit breaking for docling-serve

## Summary

docling-serve instances crash under memory leaks. The client round-robins
requests across the fleet, but the rotation was **health-blind** — it kept
handing requests to an instance that had already crashed, so ~1/fleet-size of
all requests failed against a known-dead node until something external removed
it.

This PR adds a per-instance circuit breaker. After an instance fails enough
times, its breaker opens and `_pick_url` skips it; after a cooldown the breaker
auto-probes, and a successful request closes it. The fleet now routes around a
crashed/leaking instance instead of repeatedly hitting it.

## Changes

`providers/docling_serve.py`:

- **`_InstanceBreaker`** — a small, self-contained closed/open-with-cooldown
  breaker. Kept local rather than reusing the ingester's `CircuitBreaker` so the
  provider layer doesn't take a backwards dependency on the ingester package
  (whose `pollers/__init__` would also pull in a circular import).
- **`_instance_breakers`** — process-global registry keyed by base URL (mirrors
  the existing `_instance_rotators`), so an instance that crashed stays skipped
  across the per-job clients until its cooldown elapses.
- **`_is_instance_failure(exc)`** — only transport errors (connection reset /
  timeout) and HTTP 5xx / 408 / 429 count against instance health. Other 4xx
  (caller's fault) and the task-level `ValueError` from `_submit_and_wait`
  (document problem) do not trip the breaker.
- **`_pick_url()`** — skips instances whose breaker is open, falling back to the
  first-seen instance when every breaker is open (a single-instance or
  fully-down fleet still gets a probe rather than no attempt).
- **`submit_and_poll` / `submit_and_poll_zip`** — record success/failure per
  request via `_record_outcome`, which trips the breaker only on instance-health
  failures and logs a warning when a breaker opens.
- New constructor params: `breaker_failure_threshold` (default 3),
  `breaker_cooldown_s` (default 30s), and an injectable `now_fn` (for tests).
  Not yet wired to `providers.docling_serve` config — a trivial follow-up.

## Behavior

- Instance fails `threshold` times → breaker opens → subsequent `_pick_url`
  calls skip it for `cooldown_s`.
- After the cooldown the breaker allows one probe; success closes it, another
  failure re-opens it.
- 4xx and task-level errors leave the breaker untouched.
- All-open fleet / single-instance fleet still gets a probe (no hard failure
  from "nothing to pick").
- Success path is otherwise unchanged: all-closed breakers behave exactly like
  the prior round-robin (existing distribution / lifecycle-pinning tests pass
  unchanged).

## Scope / relationship to retry+failover

This is built on the current baseline; the reactive retry-on-another-instance
change (in-request failover) is a separate PR. The two compose: this breaker
records outcomes and skips dead instances at pick time, while the retry PR adds
per-request failover and a `_pick_url(exclude=...)` argument. The only merge
point is `_pick_url`'s signature (combine breaker-skipping with the per-request
`exclude` set) — straightforward.

## Testing

- `tests/test_docling_serve_client.py` — 10 passed (7 existing + 3 new):
  - open breaker skips the crashed instance (later requests never attempt it);
  - breaker recovers after cooldown (injected clock) and a success closes it;
  - a 4xx does not trip the breaker even at a 1-failure threshold.
  - Existing round-robin / lifecycle-pinning tests still pass, confirming the
    all-healthy success path is unchanged.
- `ruff check` clean on changed files.

Note: three `TestDoclingServeConverter` tests (`test_convert_file_text`,
`test_convert_file_pdf`, `test_parse_zip_leaves_unknown_artifact_uri_unchanged`)
fail on Windows with a `PermissionError` reopening a `NamedTemporaryFile` — a
pre-existing environment issue, confirmed failing identically on the baseline
without this change; they pass on Linux/CI.
