### PR TITLE
performance updates to duplicate checking

### DIFF
--- a/haiku_rag_slim/haiku/rag/doctor.py
+++ b/haiku_rag_slim/haiku/rag/doctor.py
@@ -252,9 +252,18 @@ def _unit(vector: np.ndarray) -> np.ndarray:
     return vector / norm if norm else vector
 
 
-def _containment(source: np.ndarray, target: np.ndarray, twin: float) -> float:
-    """Fraction of ``source`` chunks with a near-identical chunk in ``target``."""
-    return float(((source @ target.T).max(axis=1) >= twin).mean())
+def _containment(a: np.ndarray, b: np.ndarray, twin: float) -> tuple[float, float]:
+    """Directed chunk-overlap containment in both directions from one product.
+
+    Returns ``(a_in_b, b_in_a)`` where each value is the fraction of one
+    document's chunks that have a near-identical chunk in the other. Both
+    directions are the row-max and column-max of the same similarity matrix, so
+    the matmul is computed once rather than once per direction.
+    """
+    sims = a @ b.T
+    a_in_b = float((sims.max(axis=1) >= twin).mean())
+    b_in_a = float((sims.max(axis=0) >= twin).mean())
+    return a_in_b, b_in_a
 
 
 def _duplicate_families(
@@ -270,7 +279,7 @@ def _duplicate_families(
     # floor; normalize the rest to unit length.
     normalized: dict[str, np.ndarray] = {}
     for doc_id, matrix in doc_vectors.items():
-        m = np.asarray(matrix, dtype=float)
+        m = np.asarray(matrix, dtype=np.float32)
         if m.ndim != 2 or m.shape[0] == 0:
             continue
         m = m[np.linalg.norm(m, axis=1) > 0]
@@ -321,11 +330,8 @@ def _duplicate_families(
     adjacency: dict[int, set[int]] = {}
     edges: dict[tuple[int, int], tuple[float, float]] = {}
     for i, j in candidates:
-        a_to_b = _containment(
+        a_to_b, b_to_a = _containment(
             normalized[order[i]], normalized[order[j]], cfg.twin_similarity
-        )
-        b_to_a = _containment(
-            normalized[order[j]], normalized[order[i]], cfg.twin_similarity
         )
         if max(a_to_b, b_to_a) >= cfg.containment_threshold:
             adjacency.setdefault(i, set()).add(j)
@@ -661,7 +667,12 @@ async def run_db_checks(
         )
 
     ids = arrow.column("id").to_pylist()
-    vectors = np.asarray(arrow.column("vector").to_pylist(), dtype=float)
+    # Reshape the Arrow fixed-size-list child buffer directly into an (N, dim)
+    # float32 matrix. Going through to_pylist() would box N*dim Python floats
+    # (tens of GB and the bulk of the wall-clock on large corpora); the stored
+    # vectors are already float32, so this keeps the layout and the dtype.
+    vec_col = arrow.column("vector").combine_chunks()
+    vectors = vec_col.values.to_numpy(zero_copy_only=False).reshape(-1, actual_dim)
     zero_ids: list[str] = []
     if vectors.size:
         zero_ids = [ids[i] for i in np.nonzero(~vectors.any(axis=1))[0]]
@@ -686,6 +697,9 @@ async def run_db_checks(
     for index, doc_id in enumerate(chunk_doc_ids_ordered):
         indices_by_doc.setdefault(doc_id, []).append(index)
     doc_vectors = {doc_id: vectors[idx] for doc_id, idx in indices_by_doc.items()}
+    # Per-doc fancy indexing has copied every vector; release the full matrix so
+    # both copies are not resident during duplicate detection.
+    del vectors
     results.append(
         _check_duplicate_documents(
             doc_vectors,


### PR DESCRIPTION
# perf: speed up and shrink memory of doctor's duplicate-document check

## Summary

`haiku-rag doctor` ran the near-duplicate-document check by loading every
chunk vector through Arrow's `to_pylist()`. On large databases this took
**over an hour** and consumed **more than 32 GB of memory**.

The root cause was that the heaviest part of the check materialized the
whole vector column as a Python list-of-lists before handing it to NumPy:

```python
vectors = np.asarray(arrow.column("vector").to_pylist(), dtype=float)
```

For a corpus of ~2M chunks × 1024 dims this boxes ~2 billion Python float
objects (tens of GB of transient allocation, and the bulk of the
wall-clock), then stores the result as float64 — double the size of the
stored float32 vectors.

## Changes

All changes are contained to `haiku/rag/doctor.py`. No behavior change:
same thresholds, same duplicate families.

1. **Vectorized vector load.** Reshape the Arrow fixed-size-list child
   buffer directly into an `(N, dim)` matrix instead of going through
   `to_pylist()`. The stored vectors are already float32, so this keeps
   both the layout and the dtype:

   ```python
   vec_col = arrow.column("vector").combine_chunks()
   vectors = vec_col.values.to_numpy(zero_copy_only=False).reshape(-1, actual_dim)
   ```

   This eliminates the billions of boxed Python floats and halves the
   resident array (float32 vs float64). It is the primary fix for both
   the runtime and the memory blowout.

2. **Release the full matrix early.** After per-document slicing has
   copied every vector into `doc_vectors`, `del vectors` so both copies
   are not resident at once during clustering.

3. **float32 inside `_duplicate_families`.** Normalize as `np.float32`
   instead of float64: half the memory and roughly 2× faster BLAS
   matmuls. Cosine thresholding does not need float64 precision.

4. **One matmul per candidate pair.** `_containment` now returns both
   containment directions from a single `a @ b.T` product (row-max and
   column-max) instead of computing the product once per direction.
   This halves the Stage-2 verification cost.

## Impact

- Removes the multi-GB transient allocation from `to_pylist()` and the
  float64 doubling — the direct cause of the >32 GB usage.
- Cuts the dominant runtime cost (Python object construction) and the
  Stage-2 matmul work.
- The only numeric difference is float32 vs float64 accumulation in the
  cosine products, which is well within the threshold margins.

## Testing

- `uv run pytest tests/test_doctor.py` — 79 passed.
- `uv run ruff check` / `uv run ruff format --check` — clean.

Not yet measured against a production-scale database; the expected
order-of-magnitude improvement follows from removing the `to_pylist()`
object explosion rather than a benchmarked result.
