### PR TITLE
Allow updating a document's uri via update_document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 ## [Unreleased]
 
+### Added
+
+- `update_document` accepts a `uri` argument to change a document's URI.
+
 ## [0.63.2] - 2026-07-03
 
 ### Changed

--- a/docs/python.md
+++ b/docs/python.md
@@ -141,6 +141,9 @@ await client.update_document(
 # Update title only (no re-chunking)
 await client.update_document(document_id=doc.id, title="New Title")
 
+# Update uri only (no re-chunking)
+await client.update_document(document_id=doc.id, uri="file:///new/path.txt")
+
 # Update multiple fields at once
 await client.update_document(
     document_id=doc.id,

--- a/haiku_rag_slim/haiku/rag/client/__init__.py
+++ b/haiku_rag_slim/haiku/rag/client/__init__.py
@@ -304,6 +304,7 @@ class HaikuRAG:
         chunks: list[Chunk] | None = None,
         title: str | None = None,
         docling_document: "DoclingDocument | None" = None,
+        uri: str | None = None,
     ) -> Document:
         from haiku.rag.client.documents import update_document
 
@@ -315,6 +316,7 @@ class HaikuRAG:
             chunks,
             title,
             docling_document,
+            uri,
         )
 
     async def get_document_by_id(self, document_id: str) -> Document | None:

--- a/haiku_rag_slim/haiku/rag/client/documents.py
+++ b/haiku_rag_slim/haiku/rag/client/documents.py
@@ -810,6 +810,7 @@ async def update_document(
     chunks: list[Chunk] | None = None,
     title: str | None = None,
     docling_document: "DoclingDocument | None" = None,
+    uri: str | None = None,
 ) -> Document:
     """Update a document by ID.
 
@@ -837,6 +838,8 @@ async def update_document(
         existing_doc.title = title
     if metadata is not None:
         existing_doc.metadata = metadata
+    if uri is not None:
+        existing_doc.uri = uri
 
     if content is None and chunks is None and docling_document is None:
         updated = await client.document_repository.update_meta(existing_doc)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -256,6 +256,16 @@ async def test_client_update_document(qa_corpus: list[dict[str, str]], temp_db_p
         assert doc_chunks[0].content == "Custom chunk 1"
         assert doc_chunks[1].content == "Custom chunk 2"
 
+        # Test updating only the uri
+        new_uri = "file:///path/to/new.txt"
+        updated_doc = await client.update_document(document_id=original_id, uri=new_uri)
+        assert updated_doc.uri == new_uri
+        refetched = await client.get_document_by_id(original_id)
+        assert refetched is not None
+        assert refetched.uri == new_uri
+        assert (await client.get_document_by_uri(new_uri)) is not None
+        assert (await client.get_document_by_uri(test_uri)) is None
+
 
 @pytest.mark.vcr()
 async def test_client_create_document_from_source(temp_db_path):


### PR DESCRIPTION
Fixes #484. uri was a mutable storage column but not exposed on
update_document. Thread a uri parameter through the client and set it
alongside the existing title/metadata updates.