### PR TITLE
Prevent magic-byte sniffing from misrouting text conversion in docling-local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 ## [Unreleased]
 
+### Fixed
+
+- `docling-local` text conversion no longer misroutes markdown/HTML content whose first bytes collide with a binary magic signature (e.g. `BM`, `ID3`) to an image or audio backend.
+
 ## [0.66.0] - 2026-07-14
 
 ### Changed

--- a/haiku_rag_slim/haiku/rag/converters/docling_local.py
+++ b/haiku_rag_slim/haiku/rag/converters/docling_local.py
@@ -311,7 +311,12 @@ class DoclingLocalConverter(DocumentConverter):
         from docling.exceptions import ConversionError
         from docling_core.types.io import DocumentStream
 
-        bytes_io = BytesIO(text.encode("utf-8"))
+        # Docling sniffs magic bytes before considering the extension, so text
+        # starting with e.g. "BM" (BMP) or "ID3" (MP3) gets routed to a binary
+        # backend. A leading newline defeats every magic signature (all match
+        # at offset 0) without changing the md/html parse, making docling fall
+        # back to the extension in doc_name, which encodes the known format.
+        bytes_io = BytesIO(b"\n" + text.encode("utf-8"))
         doc_stream = DocumentStream(name=doc_name, stream=bytes_io)
         converter = DoclingDocConverter(
             format_options=self._build_format_options(source_uri=source_uri)

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -321,6 +321,24 @@ class TestTextToDoclingWithFormat:
         assert "MZ Wallace" in exported
 
     @pytest.mark.asyncio
+    async def test_text_starting_with_magic_bytes_parses_as_markdown(self):
+        """Text whose first bytes collide with a binary magic signature
+        ("BM" = BMP, "ID3" = MP3) must still be parsed as markdown, not
+        routed to an image/audio backend by content sniffing.
+        """
+        config = AppConfig()
+        converter = DoclingLocalConverter(config)
+
+        for prefix in ("BMW", "ID3 Algorithm"):
+            text = f"{prefix} overview.\n\n## History\n\n- First item\n- Second item"
+            doc = await converter.convert_text(text, format="md")
+            labels = [
+                str(getattr(item, "label", "")) for item, _ in doc.iterate_items()
+            ]
+            assert "section_header" in labels
+            assert "list_item" in labels
+
+    @pytest.mark.asyncio
     async def test_plain_text_without_markdown_syntax_fallback(self):
         """Test that plain text without markdown syntax falls back gracefully.
 


### PR DESCRIPTION
Docling sniffs a stream's magic bytes before the extension, so text starting with "BM", "ID3", etc. was routed to an image/audio backend. Fixed by adding leading newline defeating the sniff.