### PR TITLE
Read verbs skip the embeddings config-compatibility check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 ## [Unreleased]
 
+### Fixed
+
+- `list`, `get`, and `visualize` no longer require an embeddings config matching the database.
+
 ## [0.67.3] - 2026-07-23
 
 ### Changed

--- a/haiku_rag_slim/haiku/rag/app.py
+++ b/haiku_rag_slim/haiku/rag/app.py
@@ -431,6 +431,7 @@ class HaikuRAGApp:  # pragma: no cover
             db_path=self.db_path,
             config=self.config,
             read_only=True,
+            skip_validation=True,
         ) as self.client:
             documents = await self.client.list_documents(filter=filter)
             for doc in documents:
@@ -480,6 +481,7 @@ class HaikuRAGApp:  # pragma: no cover
             db_path=self.db_path,
             config=self.config,
             read_only=True,
+            skip_validation=True,
         ) as self.client:
             doc = await self.client.get_document_by_id(doc_id)
             if doc is None:
@@ -557,6 +559,7 @@ class HaikuRAGApp:  # pragma: no cover
             db_path=self.db_path,
             config=self.config,
             read_only=True,
+            skip_validation=True,
         ) as self.client:
             chunk = await self.client.get_chunk_by_id(chunk_id)
             if not chunk:

--- a/tests/store/test_read_only.py
+++ b/tests/store/test_read_only.py
@@ -332,6 +332,62 @@ class TestAppReadVerbsDoNotWrite:
         assert version_after == version_before
 
     @pytest.mark.asyncio
+    async def test_list_works_with_mismatched_embeddings_config(self, temp_db_path):
+        """list skips the embeddings compatibility check and never writes."""
+        from haiku.rag.app import HaikuRAGApp
+        from haiku.rag.config import AppConfig
+
+        async with Store(temp_db_path, create=True) as store:
+            await DocumentRepository(store).create(Document(content="test content"))
+            settings_before = await SettingsRepository(store).get_current_settings()
+
+        drift = AppConfig()
+        drift.embeddings.model.name = "different-model"
+        drift.embeddings.model.vector_dim = 4096
+
+        app = HaikuRAGApp(db_path=temp_db_path, config=drift)
+        await app.list_documents()
+
+        async with Store(temp_db_path, skip_validation=True, read_only=True) as store:
+            settings_after = await SettingsRepository(store).get_current_settings()
+        assert settings_after == settings_before
+
+    @pytest.mark.asyncio
+    async def test_get_works_with_mismatched_embeddings_config(self, temp_db_path):
+        """get skips the embeddings compatibility check."""
+        from haiku.rag.app import HaikuRAGApp
+        from haiku.rag.config import AppConfig
+
+        async with Store(temp_db_path, create=True) as store:
+            doc = await DocumentRepository(store).create(
+                Document(content="test content")
+            )
+
+        drift = AppConfig()
+        drift.embeddings.model.vector_dim = 4096
+
+        app = HaikuRAGApp(db_path=temp_db_path, config=drift)
+        assert doc.id is not None
+        await app.get_document(doc.id)
+
+    @pytest.mark.asyncio
+    async def test_visualize_works_with_mismatched_embeddings_config(
+        self, temp_db_path
+    ):
+        """visualize skips the embeddings compatibility check."""
+        from haiku.rag.app import HaikuRAGApp
+        from haiku.rag.config import AppConfig
+
+        async with Store(temp_db_path, create=True):
+            pass
+
+        drift = AppConfig()
+        drift.embeddings.model.vector_dim = 4096
+
+        app = HaikuRAGApp(db_path=temp_db_path, config=drift)
+        await app.visualize_chunk("missing-chunk-id")
+
+    @pytest.mark.asyncio
     async def test_write_verb_raises_on_drift_without_writing(self, temp_db_path):
         """A write CLI verb opens writable: drift raises before any write."""
         from haiku.rag.app import HaikuRAGApp


### PR DESCRIPTION
`list`, `get`, and `visualize` open the store read-only and never embed, but did not pass `skip_validation=True`, so running them with a config that does not match the stored embedder (e.g. `vector_dim` drift) raised `ConfigMismatchError`.

They now skip the check, like the other non-embedding verbs (`delete`, `vacuum`, `migrate`, `create-index`, `history`, `tag`) already do. Reads are safe regardless of config since the chunk schema is built from the stored vector dimension. Verbs that embed (`search`, `ask`, `analyze`, `add`, `mcp`, `chat`, `inspect`) keep the check.