### PR TITLE
add deadlock mitigations for vacuum

### DIFF
--- a/haiku_rag_slim/haiku/rag/config/models.py
+++ b/haiku_rag_slim/haiku/rag/config/models.py
@@ -59,6 +59,11 @@ class StorageConfig(BaseModel):
     data_dir: Path = Field(default_factory=get_default_data_dir)
     auto_vacuum: bool = True
     vacuum_retention_seconds: int = 86400
+    # Upper bound (seconds) on a single vacuum/optimize pass. ``None`` leaves it
+    # unbounded (the historical behavior). A finite value converts a stuck
+    # compaction into a logged, skipped pass instead of an unbounded hang that
+    # would also wedge client teardown (which drains background vacuums).
+    vacuum_timeout_seconds: float | None = None
 
 
 class LanceDBConfig(BaseModel):

--- a/haiku_rag_slim/haiku/rag/store/engine.py
+++ b/haiku_rag_slim/haiku/rag/store/engine.py
@@ -571,14 +571,29 @@ class Store:
                 # Evaluate config at runtime to allow dynamic changes
                 if retention_seconds is None:
                     retention_seconds = self._config.storage.vacuum_retention_seconds
-                # Perform maintenance per table using optimize() with configurable retention
-                retention = timedelta(seconds=retention_seconds)
-                for table in self._tables().values():
-                    await table.optimize(
-                        cleanup_older_than=await self._tag_safe_retention(
-                            table, retention
+                # Bound the pass so a stuck compaction degrades to a logged,
+                # skipped pass rather than an unbounded await -- which would also
+                # wedge client teardown (__aexit__ drains background vacuums).
+                # timeout=None leaves it unbounded (historical behavior).
+                timeout = self._config.storage.vacuum_timeout_seconds
+                async with asyncio.timeout(timeout):
+                    # Perform maintenance per table using optimize() with configurable retention
+                    retention = timedelta(seconds=retention_seconds)
+                    for table in self._tables().values():
+                        await table.optimize(
+                            cleanup_older_than=await self._tag_safe_retention(
+                                table, retention
+                            )
                         )
-                    )
+            except TimeoutError:
+                # The pass is best-effort maintenance; a timeout is not fatal.
+                # NOTE: cancellation only takes effect if the underlying
+                # operation is cancellable -- a fully-unresponsive native future
+                # may still linger, but the caller's coroutine is freed.
+                logger.warning(
+                    "Vacuum timed out after %ss; skipping this pass",
+                    self._config.storage.vacuum_timeout_seconds,
+                )
             except OSError as e:
                 # Resource errors (e.g. disk pressure) skip the pass; lance
                 # errors surface as RuntimeError and must not be swallowed —

--- a/tests/test_vacuum_debounce.py
+++ b/tests/test_vacuum_debounce.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 
 import pytest
 
@@ -16,6 +17,58 @@ def _docling_doc(name: str, text: str):
     doc = DoclingDocument(name=name)
     doc.add_text(label=DocItemLabel.TEXT, text=text)
     return doc
+
+
+@pytest.mark.asyncio
+async def test_vacuum_times_out_and_skips(temp_db_path, monkeypatch, caplog):
+    """A stuck optimize is bounded by storage.vacuum_timeout_seconds: the pass
+    is skipped (logged), the call returns instead of hanging, and no exception
+    propagates."""
+
+    class _SlowTable:
+        async def optimize(self, **_kwargs):
+            await asyncio.sleep(30)  # far longer than the timeout
+
+    async with HaikuRAG(temp_db_path, create=True) as client:
+        store = client.store
+        # setattr (not direct assignment) so the shared global Config is restored.
+        monkeypatch.setattr(store._config.storage, "vacuum_timeout_seconds", 0.05)
+        monkeypatch.setattr(store, "_tables", lambda: {"t": _SlowTable()})
+
+        async def _passthrough_retention(_table, retention):
+            return retention
+
+        monkeypatch.setattr(store, "_tag_safe_retention", _passthrough_retention)
+
+        with caplog.at_level(logging.WARNING, logger="haiku.rag.store.engine"):
+            # wait_for guards the test itself from hanging if the bound fails.
+            await asyncio.wait_for(store.vacuum(), timeout=5)
+
+        assert "Vacuum timed out" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_vacuum_unbounded_when_timeout_none(temp_db_path, monkeypatch):
+    """timeout=None preserves the historical unbounded behavior (optimize runs
+    to completion)."""
+    ran: list[int] = []
+
+    class _Table:
+        async def optimize(self, **_kwargs):
+            ran.append(1)
+
+    async with HaikuRAG(temp_db_path, create=True) as client:
+        store = client.store
+        monkeypatch.setattr(store._config.storage, "vacuum_timeout_seconds", None)
+        monkeypatch.setattr(store, "_tables", lambda: {"t": _Table()})
+
+        async def _passthrough_retention(_table, retention):
+            return retention
+
+        monkeypatch.setattr(store, "_tag_safe_retention", _passthrough_retention)
+
+        await store.vacuum()
+        assert ran == [1]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Bound `vacuum`/`optimize` with an optional timeout to prevent teardown hangs

## Problem

`Store.vacuum()` awaits `table.optimize(...)` with no time bound. If a
compaction stalls in lance-core (e.g. a slow/again-locked dataset, a network or
overlay filesystem that stops responding), the `await` never returns. Because
vacuum is reached from three places — an explicit `client.vacuum()`, the
throttled background `_schedule_vacuum()` task, and the close-time drain in
`HaikuRAG.__aexit__` → `_await_vacuum_tasks()` (which `await`s outstanding
background vacuums **and** runs a final `store.vacuum()`) — a single stuck
optimize can **wedge client teardown indefinitely**. `async with HaikuRAG(...)
as client: ...` then hangs on exit and the process never returns.

This surfaced when running an in-process vacuum after ingestion: the main event
loop parks in `select()` forever, waiting on the optimize future.

## Change

Add `StorageConfig.vacuum_timeout_seconds: float | None = None` and wrap the
optimize loop in `asyncio.timeout(...)`:

- **`None` (default) → unbounded**, i.e. no behavior change for existing users.
- A finite value converts a stuck pass into a **logged, skipped** pass
  (`"Vacuum timed out after …s; skipping this pass"`), handled alongside the
  existing `OSError` skip. Vacuum is best-effort maintenance, so a timeout is
  non-fatal — the caller's coroutine is freed and teardown proceeds.

Because all three entry points funnel through `Store.vacuum()`, this one bound
protects explicit vacuums, background vacuums, and `__aexit__` teardown.

## Files

- `haiku_rag_slim/haiku/rag/config/models.py` — new `vacuum_timeout_seconds`
  field on `StorageConfig`.
- `haiku_rag_slim/haiku/rag/store/engine.py` — `Store.vacuum()` wraps the
  per-table `optimize()` loop in
  `asyncio.timeout(self._config.storage.vacuum_timeout_seconds)`; new
  `except TimeoutError` logs + skips.
- `tests/test_vacuum_debounce.py` — `test_vacuum_times_out_and_skips` (a slow
  `optimize` is bounded, logged, returns without raising) and
  `test_vacuum_unbounded_when_timeout_none` (default runs to completion).

## Caveats

- **Best-effort cancellation.** `asyncio.timeout` frees the awaiting coroutine,
  but if the underlying lance/native future doesn't honor cancellation the
  operation may linger in the background — the guarantee is "the caller/teardown
  no longer hangs," not a forced abort of the native work.
- Opt-in by default (`None`), so it's a safe, non-breaking addition; set
  `storage.vacuum_timeout_seconds` to activate.

## Testing

`uv run pytest tests/test_vacuum_debounce.py tests/test_versioning.py tests/store/test_tags.py`
— new timeout tests pass, and the existing vacuum-on-close / tag-retention /
versioning paths are unaffected (42 passed). `ruff check` / `ruff format` clean.

