### PR TITLE
Fix for missing timezone info on ingested docs. mcp schema requires TZ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 ### Fixed
 
 - Document timestamps include timezone information and satisfy the MCP
-  date-time output schema.
+  date-time output schema. Stored timestamps without an offset are read as
+  host-local time; a database written under a different host timezone shifts
+  by that offset.
 
 ## [0.82.0] - 2026-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Document timestamps include timezone information and satisfy the MCP
+  date-time output schema.
+
 ## [0.82.0] - 2026-09-03
 
 ### Removed

--- a/haiku_rag_slim/haiku/rag/client/rebuild.py
+++ b/haiku_rag_slim/haiku/rag/client/rebuild.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import logging
 from collections.abc import AsyncGenerator
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from docling_core.types.doc.document import DescriptionMetaField, PictureMeta
@@ -531,7 +531,7 @@ async def _flush_rebuild_batch(
     if not documents:
         return
 
-    now = datetime.now().isoformat()
+    now = datetime.now(UTC).isoformat()
 
     # Batch update documents and document_meta using merge_insert (one LanceDB
     # version per table). Content+blobs go to documents; mutable attributes go

--- a/haiku_rag_slim/haiku/rag/store/models/document.py
+++ b/haiku_rag_slim/haiku/rag/store/models/document.py
@@ -1,8 +1,8 @@
 import json
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from haiku.rag.store.compression import compress_docling_split, decompress_json
 
@@ -29,8 +29,19 @@ class Document(BaseModel):
     docling_document: bytes | None = Field(default=None, exclude=True)
     docling_pages: bytes | None = Field(default=None, exclude=True)
     docling_version: str | None = Field(default=None, exclude=True)
-    created_at: datetime = Field(default_factory=datetime.now)
-    updated_at: datetime = Field(default_factory=datetime.now)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    @field_validator("created_at", "updated_at")
+    @classmethod
+    def _assume_utc(cls, value: datetime) -> datetime:
+        """Attach UTC to a timezone-less timestamp instead of leaving it ambiguous.
+
+        A row written before timestamps carried an explicit offset parses back
+        with no tzinfo. Treat it as UTC rather than pass it on naive, which the
+        MCP tools' declared JSON schema rejects as an invalid date-time.
+        """
+        return value if value.tzinfo else value.replace(tzinfo=UTC)
 
     def set_docling(self, docling_doc: "DoclingDocument") -> None:
         """Serialize and store a DoclingDocument, splitting structure and pages.

--- a/haiku_rag_slim/haiku/rag/store/models/document.py
+++ b/haiku_rag_slim/haiku/rag/store/models/document.py
@@ -34,14 +34,8 @@ class Document(BaseModel):
 
     @field_validator("created_at", "updated_at")
     @classmethod
-    def _assume_utc(cls, value: datetime) -> datetime:
-        """Attach UTC to a timezone-less timestamp instead of leaving it ambiguous.
-
-        A row written before timestamps carried an explicit offset parses back
-        with no tzinfo. Treat it as UTC rather than pass it on naive, which the
-        MCP tools' declared JSON schema rejects as an invalid date-time.
-        """
-        return value if value.tzinfo else value.replace(tzinfo=UTC)
+    def _to_utc(cls, value: datetime) -> datetime:
+        return value if value.tzinfo else value.astimezone(UTC)
 
     def set_docling(self, docling_doc: "DoclingDocument") -> None:
         """Serialize and store a DoclingDocument, splitting structure and pages.

--- a/haiku_rag_slim/haiku/rag/store/repositories/document.py
+++ b/haiku_rag_slim/haiku/rag/store/repositories/document.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import overload
 from uuid import uuid4
 
@@ -77,8 +77,8 @@ class DocumentRepository:
             docling_document=doc.docling_document,
             docling_pages=doc.docling_pages,
             docling_version=doc.docling_version,
-            created_at=datetime.fromisoformat(created) if created else datetime.now(),
-            updated_at=datetime.fromisoformat(updated) if updated else datetime.now(),
+            created_at=datetime.fromisoformat(created) if created else datetime.now(UTC),
+            updated_at=datetime.fromisoformat(updated) if updated else datetime.now(UTC),
         )
 
     def _to_documents_record(self, entity: Document, doc_id: str) -> DocumentRecord:
@@ -138,7 +138,7 @@ class DocumentRepository:
         # document_meta) would surface.
         if isinstance(entity, Document):
             doc_id = str(uuid4())
-            now = datetime.now().isoformat()
+            now = datetime.now(UTC).isoformat()
             await self.store.document_meta_table.add(
                 [self._to_meta_record(entity, doc_id, now, now)]
             )
@@ -159,7 +159,7 @@ class DocumentRepository:
         if not documents:
             return []
 
-        now = datetime.now().isoformat()
+        now = datetime.now(UTC).isoformat()
         created_at = datetime.fromisoformat(now)
         doc_records = []
         meta_records = []
@@ -272,7 +272,7 @@ class DocumentRepository:
         self.store._assert_writable()
         assert entity.id, "Document ID is required for update"
 
-        now = datetime.now().isoformat()
+        now = datetime.now(UTC).isoformat()
         entity.updated_at = datetime.fromisoformat(now)
         created = entity.created_at.isoformat() if entity.created_at else now
         record = self._to_meta_record(entity, entity.id, created, now)

--- a/haiku_rag_slim/haiku/rag/store/repositories/document.py
+++ b/haiku_rag_slim/haiku/rag/store/repositories/document.py
@@ -77,8 +77,12 @@ class DocumentRepository:
             docling_document=doc.docling_document,
             docling_pages=doc.docling_pages,
             docling_version=doc.docling_version,
-            created_at=datetime.fromisoformat(created) if created else datetime.now(UTC),
-            updated_at=datetime.fromisoformat(updated) if updated else datetime.now(UTC),
+            created_at=datetime.fromisoformat(created)
+            if created
+            else datetime.now(UTC),
+            updated_at=datetime.fromisoformat(updated)
+            if updated
+            else datetime.now(UTC),
         )
 
     def _to_documents_record(self, entity: Document, doc_id: str) -> DocumentRecord:

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1,3 +1,7 @@
+import os
+import time
+from datetime import UTC, datetime
+
 import pytest
 
 from haiku.rag.store.engine import Store
@@ -549,3 +553,28 @@ async def test_document_get_by_uri_with_special_characters(
         assert retrieved is not None
         assert retrieved.id == created_doc.id
         assert retrieved.uri == "Hamish and Andy's Gap Year"
+
+
+@pytest.mark.skipif(not hasattr(time, "tzset"), reason="time.tzset is POSIX-only")
+def test_naive_timestamp_is_converted_from_local_time():
+    original_tz = os.environ.get("TZ")
+    os.environ["TZ"] = "Europe/Athens"
+    time.tzset()
+    try:
+        created = datetime(2026, 1, 1, 14, 0, 0)  # January is EET, UTC+2
+        updated = datetime(2026, 1, 1, 14, 30, 0)
+        doc = Document(content="x", created_at=created, updated_at=updated)
+        assert doc.created_at == datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        assert doc.updated_at == datetime(2026, 1, 1, 12, 30, 0, tzinfo=UTC)
+    finally:
+        if original_tz is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = original_tz
+        time.tzset()
+
+
+def test_created_at_serializes_with_timezone_offset():
+    doc = Document(content="x")
+    value = doc.model_dump(mode="json")["created_at"]
+    assert datetime.fromisoformat(value).utcoffset() is not None


### PR DESCRIPTION
When a document is saved, haiku.rag stamps it with a "created at" and "updated at" time using `datetime.now()`. That gives a time with no timezone attached, for example 2026-09-01T16:56:29.958257.

The `get_document` MCP tool publishes a JSON schema that says these two fields must be a date-time, which in context means RFC 3339, not plain ISO 8601. RFC 3339 requires the timezone to be stated, either as Z for UTC or as an offset like +01:00; ISO 8601 permits omitting it. This does not seem to be enforced by a lot of tools, including `FastMCP`'s client.

Claude Code's MCP client does enforce it however, and calling `get_document` therefore errors with:

>Error: Structured content does not match the tool's output schema: data/result/created_at must match format "date-time", data/result/updated_at must match format "date-time", data/result must be null, data/result must match a schema in anyOf ...

I have added a `field_validator` on `Document.created_at`/`updated_at` that attaches UTC to any naive value at construction time, and switched every write site to `datetime.now(UTC)`. 

I think there is a risk for documents which have been ingested before this fix. Whilst we can treat a date without a TZ as UTC and correct for it, that of course assumes that the server's local time is indeed UTC.  The displayed time on old records from a non-UTC database will therefore be out by a fixed number of hours.  