### PR TITLE
Update every GitHub Action to its latest major

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -17,13 +17,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v9.0.0
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v10.0.1
       - run: uv sync --group dev
       - run: uv run zensical build
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@v6
         if: github.event_name == 'push'
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         if: github.event_name == 'push'
         with:
           path: ./site
@@ -36,4 +36,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/build-publish-slim.yml
+++ b/.github/workflows/build-publish-slim.yml
@@ -8,12 +8,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v9.0.0
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version-file: "pyproject.toml"
       - name: Build haiku.rag-slim

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v9.0.0
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version-file: "pyproject.toml"
       - name: Build haiku.rag

--- a/.github/workflows/docker-publish-slim.yml
+++ b/.github/workflows/docker-publish-slim.yml
@@ -25,13 +25,13 @@ jobs:
           docker-images: true
           swap-storage: true
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -44,7 +44,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Build and push Docker slim image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile.slim

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
       - name: Generate server.json from template

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,12 +10,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v9.0.0
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version-file: ".python-version"
       - name: Install dependencies
@@ -28,12 +28,12 @@ jobs:
   lint-frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
         with:
           version: 10
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: "pnpm"
@@ -53,8 +53,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python: ["3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v9.0.0
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v10.0.1
       # --noconftest: tests/conftest.py imports the project's dependencies,
       # which this job deliberately does not install. test_uri.py is stdlib-only.
       - name: Test platform URI paths
@@ -70,19 +70,19 @@ jobs:
     env:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v9.0.0
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version-file: ".python-version"
       - name: Install dependencies
         run: uv sync --all-extras
       - name: Cache HuggingFace models
         id: hf-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/huggingface
           key: huggingface-${{ runner.os }}-test-models-v2
@@ -98,7 +98,7 @@ jobs:
           TRANSFORMERS_OFFLINE: ${{ steps.hf-cache.outputs.cache-hit == 'true' && '1' || '0' }}
         run: uv run pytest -m "not integration" --cov --cov-report=xml --cov-report=term-missing:skip-covered
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml


### PR DESCRIPTION
Every action targeted Node 20, which the runners now force onto Node 24.

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | v4 (×8) | v7 |
| `actions/setup-python` | v5 (×4), v6 | v7 |
| `actions/cache` | v4 | v6 |
| `actions/setup-node` | v4 | v7 |
| `actions/configure-pages` | v5 | v6 |
| `actions/upload-pages-artifact` | v3 | v5 |
| `actions/deploy-pages` | v4 | v5 |
| `astral-sh/setup-uv` | v9.0.0 (×5) | v10.0.1 |
| `codecov/codecov-action` | v5 | v7 |
| `pnpm/action-setup` | v4 | v6 |
| `docker/setup-buildx-action` | v3 | v4 |
| `docker/login-action` | v3 | v4 |
| `docker/build-push-action` | v6 | v7 |

Two flagged actions are nested and follow their parents: `actions/upload-artifact` inside `upload-pages-artifact`, `actions/github-script` inside `codecov-action`. `jlumbroso/free-disk-space@main` is unpinned and unchanged.

No `with:` block changed. The majors that removed inputs do not reach us: `setup-buildx-action` is called with no inputs, `build-push-action` uses no `DOCKER_BUILD_*` env, and `setup-node` keeps an explicit `cache: "pnpm"`, so v5/v6 package-manager auto-detection is inert.

Behaviour changes carried along:

- setup-uv v10 disables the cache under `enable-cache: auto` for `release`, `workflow_run` and `pull_request_target`. Those events drive the publish chain (`build-publish-slim` → `build-publish` → `publish-mcp`), which passes `enable-cache: true` explicitly; the only `auto` job is `test-uri-platforms`, on push/pull_request.
- `upload-pages-artifact` v4 excludes dotfiles from the artifact. `zensical build` writes `./site` and the Pages artifact path needs no `.nojekyll`.