### PR TITLE
Recover InlineGroup text for import_document/import_documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Conversion flattens each inline group of text runs into the item that owns
   it. Hyperlinks are dropped from heading text. A full `haiku-rag rebuild`
   applies the fix to existing databases.
+- `import_document`/`import_documents` store an item whose text docling
+  placed in a child `InlineGroup` with that group's text. The group's own
+  rows remain. An inline image inside the group is dropped instead of
+  stored as docling's markdown placeholder. Table rows in `document_items`
+  are now stored without markdown escaping too.
 
 ## [0.84.0] - 2026-09-10
 
@@ -143,9 +148,6 @@
   not checked against the deadline.
 - Context expansion keeps the item a result matched on when it carries a
   noise label, and counts it toward the character budget.
-- `import_document`/`import_documents` store an item whose text docling
-  placed in a child `InlineGroup` with that group's text. The group's own
-  rows remain.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,12 +143,9 @@
   not checked against the deadline.
 - Context expansion keeps the item a result matched on when it carries a
   noise label, and counts it toward the character budget.
-- `import_document`/`import_documents` store the caller's `DoclingDocument`
-  as given, so a heading or list item docling had pushed into a child
-  `InlineGroup` still landed with an empty `document_items` row there.
-  `extract_item_text` now recovers it from that group. The group's own
-  child rows stay in the table too, so the recovered item and its fragments
-  both land in expanded context.
+- `import_document`/`import_documents` store an item whose text docling
+  placed in a child `InlineGroup` with that group's text. The group's own
+  rows remain.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,12 @@
   not checked against the deadline.
 - Context expansion keeps the item a result matched on when it carries a
   noise label, and counts it toward the character budget.
+- `import_document`/`import_documents` store the caller's `DoclingDocument`
+  as given, so a heading or list item docling had pushed into a child
+  `InlineGroup` still landed with an empty `document_items` row there.
+  `extract_item_text` now recovers it from that group. The group's own
+  child rows stay in the table too, so the recovered item and its fragments
+  both land in expanded context.
 
 ### Removed
 

--- a/haiku_rag_slim/haiku/rag/store/models/document_item.py
+++ b/haiku_rag_slim/haiku/rag/store/models/document_item.py
@@ -82,11 +82,28 @@ def extract_item_text(
       so pictures carry meaningful prose into chunk text and survive
       ``expand_with_items``' ``if item.text:`` filter; otherwise fall back to
       the picture's caption text.
+    - Items whose own text is empty because docling pushed mixed inline
+      content (e.g. a paragraph or list item containing a code span or link)
+      into a child InlineGroup instead: serialize that group, the same way
+      docling itself renders it back to markdown.
     """
-    from docling_core.types.doc.document import PictureItem, TableItem
+    from docling_core.types.doc.document import InlineGroup, PictureItem, TableItem
 
     if text := getattr(item, "text", None):
         return text
+
+    def _serialize(target: Any) -> str | None:
+        try:
+            serializer = get_serializer() if get_serializer is not None else None
+            if serializer is None:
+                from docling_core.transforms.serializer.markdown import (
+                    MarkdownDocSerializer,
+                )
+
+                serializer = MarkdownDocSerializer(doc=docling_doc)
+            return serializer.serialize(item=target).text
+        except Exception:
+            return None
 
     if isinstance(item, PictureItem):
         if description := _picture_description_text(item):
@@ -94,18 +111,12 @@ def extract_item_text(
         return _picture_caption_text(item, docling_doc)
 
     if isinstance(item, TableItem):
-        try:
-            if get_serializer is None:
-                from docling_core.transforms.serializer.markdown import (
-                    MarkdownDocSerializer,
-                )
+        return _serialize(item)
 
-                serializer = MarkdownDocSerializer(doc=docling_doc)
-            else:
-                serializer = get_serializer()
-            return serializer.serialize(item=item).text
-        except Exception:
-            pass
+    if item.children:
+        first_child = item.children[0].resolve(docling_doc)
+        if isinstance(first_child, InlineGroup):
+            return _serialize(first_child)
 
     return None
 

--- a/haiku_rag_slim/haiku/rag/store/models/document_item.py
+++ b/haiku_rag_slim/haiku/rag/store/models/document_item.py
@@ -98,9 +98,13 @@ def extract_item_text(
             if serializer is None:
                 from docling_core.transforms.serializer.markdown import (
                     MarkdownDocSerializer,
+                    MarkdownParams,
                 )
 
-                serializer = MarkdownDocSerializer(doc=docling_doc)
+                serializer = MarkdownDocSerializer(
+                    doc=docling_doc,
+                    params=MarkdownParams(escape_underscores=False, escape_html=False),
+                )
             return serializer.serialize(item=target).text
         except Exception:
             return None
@@ -113,10 +117,10 @@ def extract_item_text(
     if isinstance(item, TableItem):
         return _serialize(item)
 
-    if item.children:
-        first_child = item.children[0].resolve(docling_doc)
-        if isinstance(first_child, InlineGroup):
-            return _serialize(first_child)
+    for child_ref in item.children:
+        child = child_ref.resolve(docling_doc)
+        if isinstance(child, InlineGroup):
+            return _serialize(child)
 
     return None
 
@@ -152,9 +156,13 @@ def extract_items(
         if serializer is None:
             from docling_core.transforms.serializer.markdown import (
                 MarkdownDocSerializer,
+                MarkdownParams,
             )
 
-            serializer = MarkdownDocSerializer(doc=docling_doc)
+            serializer = MarkdownDocSerializer(
+                doc=docling_doc,
+                params=MarkdownParams(escape_underscores=False, escape_html=False),
+            )
         return serializer
 
     for position, (item, level) in enumerate(docling_doc.iterate_items()):

--- a/haiku_rag_slim/haiku/rag/store/models/document_item.py
+++ b/haiku_rag_slim/haiku/rag/store/models/document_item.py
@@ -103,7 +103,11 @@ def extract_item_text(
 
                 serializer = MarkdownDocSerializer(
                     doc=docling_doc,
-                    params=MarkdownParams(escape_underscores=False, escape_html=False),
+                    params=MarkdownParams(
+                        escape_underscores=False,
+                        escape_html=False,
+                        image_placeholder="",
+                    ),
                 )
             return serializer.serialize(item=target).text
         except Exception:
@@ -161,7 +165,9 @@ def extract_items(
 
             serializer = MarkdownDocSerializer(
                 doc=docling_doc,
-                params=MarkdownParams(escape_underscores=False, escape_html=False),
+                params=MarkdownParams(
+                    escape_underscores=False, escape_html=False, image_placeholder=""
+                ),
             )
         return serializer
 

--- a/tests/store/test_document_items.py
+++ b/tests/store/test_document_items.py
@@ -1064,10 +1064,10 @@ class TestExtractItemTextInlineGroup:
             assert "pytest" in recovered.text
             assert "to test." in recovered.text
 
-            # The tradeoff ggozad asked to have written down: the group's
-            # own children are still stored as their own rows, since this
-            # path stores the document as given, so the recovered item and
-            # its fragments both land in expanded context.
+            # The group's children are stored as their own rows beside the
+            # recovered item, since this path stores the document as given,
+            # so the recovered item and its fragments both land in expanded
+            # context.
             fragment_texts = {
                 item.text for ref, item in by_ref.items() if ref != list_item.self_ref
             }

--- a/tests/store/test_document_items.py
+++ b/tests/store/test_document_items.py
@@ -891,13 +891,16 @@ async def test_replace_for_document_with_no_items_deletes_existing(temp_db_path)
         assert await repo.get_all_items("doc-1") == []
 
 
-def _doc_with_inline_group_list_item(second_child_group: bool = False):
+def _doc_with_inline_group_list_item(
+    second_child_group: bool = False, group_before_inline: bool = False
+):
     """A ListItem whose content docling pushed into a child InlineGroup
     (e.g. a list item mixing plain text with a code span). A heading gets
     the same shape. A body-level paragraph does not: its InlineGroup hangs
     directly off `#/body` with no owner item to fold the text back into.
     Optionally add a sibling nested ListGroup, matching a list item that
-    also has sub-items.
+    also has sub-items; `group_before_inline` adds it before the InlineGroup
+    instead of after, so a lookup by child position alone would miss it.
     """
     from docling_core.types.doc.document import DoclingDocument
     from docling_core.types.doc.labels import DocItemLabel, GroupLabel
@@ -905,11 +908,14 @@ def _doc_with_inline_group_list_item(second_child_group: bool = False):
     doc = DoclingDocument(name="inline")
     list_group = doc.add_group(label=GroupLabel.LIST)
     list_item = doc.add_list_item(text="", parent=list_group)
+    if second_child_group and group_before_inline:
+        nested = doc.add_group(label=GroupLabel.LIST, parent=list_item)
+        doc.add_list_item(text="Sub-item.", parent=nested)
     inline_group = doc.add_group(label=GroupLabel.INLINE, parent=list_item)
-    doc.add_text(label=DocItemLabel.TEXT, text="Run ", parent=inline_group)
+    doc.add_text(label=DocItemLabel.TEXT, text="Run snake_case & ", parent=inline_group)
     doc.add_code(text="pytest", parent=inline_group)
     doc.add_text(label=DocItemLabel.TEXT, text=" to test.", parent=inline_group)
-    if second_child_group:
+    if second_child_group and not group_before_inline:
         nested = doc.add_group(label=GroupLabel.LIST, parent=list_item)
         doc.add_list_item(text="Sub-item.", parent=nested)
     return doc, list_item
@@ -931,6 +937,21 @@ class TestExtractItemTextInlineGroup:
         assert "pytest" in text
         assert "to test." in text
 
+    def test_recovered_text_is_not_markdown_escaped(self):
+        """The fallback serializer must not escape underscores or HTML
+        entities: the recovered text is stored for search, not rendered
+        as markdown, and an escaped `snake\\_case` or `&amp;` would not
+        match the original run.
+        """
+        doc, list_item = _doc_with_inline_group_list_item()
+
+        text = extract_item_text(list_item, doc)
+        assert text is not None
+        assert "snake_case" in text
+        assert "\\_" not in text
+        assert " & " in text
+        assert "&amp;" not in text
+
     def test_extract_items_stores_non_empty_text_for_inline_group_item(self):
         doc, _ = _doc_with_inline_group_list_item()
         items = extract_items("doc-1", doc)
@@ -949,6 +970,20 @@ class TestExtractItemTextInlineGroup:
 
         text = extract_item_text(list_item, doc)
         assert text is not None
+        assert "Sub-item" not in text
+
+    def test_inline_group_recovered_regardless_of_child_position(self):
+        """A list item can carry a nested ListGroup of sub-items ordered
+        before its InlineGroup, not only after: the lookup must find the
+        InlineGroup among all children, not assume it sits at position 0.
+        """
+        doc, list_item = _doc_with_inline_group_list_item(
+            second_child_group=True, group_before_inline=True
+        )
+
+        text = extract_item_text(list_item, doc)
+        assert text is not None
+        assert "pytest" in text
         assert "Sub-item" not in text
 
     def test_reuses_passed_serializer(self, monkeypatch):
@@ -1036,7 +1071,7 @@ class TestExtractItemTextInlineGroup:
             fragment_texts = {
                 item.text for ref, item in by_ref.items() if ref != list_item.self_ref
             }
-            assert {"Run ", "pytest", " to test."} <= fragment_texts
+            assert {"Run snake_case & ", "pytest", " to test."} <= fragment_texts
 
             stored_chunk = (
                 await client.chunk_repository.get_by_document_id(imported.id)

--- a/tests/store/test_document_items.py
+++ b/tests/store/test_document_items.py
@@ -891,6 +891,159 @@ async def test_replace_for_document_with_no_items_deletes_existing(temp_db_path)
         assert await repo.get_all_items("doc-1") == []
 
 
+def _doc_with_inline_group_list_item(second_child_group: bool = False):
+    """A ListItem whose content docling pushed into a child InlineGroup
+    (e.g. a list item mixing plain text with a code span). A heading gets
+    the same shape. A body-level paragraph does not: its InlineGroup hangs
+    directly off `#/body` with no owner item to fold the text back into.
+    Optionally add a sibling nested ListGroup, matching a list item that
+    also has sub-items.
+    """
+    from docling_core.types.doc.document import DoclingDocument
+    from docling_core.types.doc.labels import DocItemLabel, GroupLabel
+
+    doc = DoclingDocument(name="inline")
+    list_group = doc.add_group(label=GroupLabel.LIST)
+    list_item = doc.add_list_item(text="", parent=list_group)
+    inline_group = doc.add_group(label=GroupLabel.INLINE, parent=list_item)
+    doc.add_text(label=DocItemLabel.TEXT, text="Run ", parent=inline_group)
+    doc.add_code(text="pytest", parent=inline_group)
+    doc.add_text(label=DocItemLabel.TEXT, text=" to test.", parent=inline_group)
+    if second_child_group:
+        nested = doc.add_group(label=GroupLabel.LIST, parent=list_item)
+        doc.add_list_item(text="Sub-item.", parent=nested)
+    return doc, list_item
+
+
+class TestExtractItemTextInlineGroup:
+    """A container item's own .text is empty when docling pushes mixed
+    inline content into a child InlineGroup; extract_item_text must recover
+    it from that group instead of leaving the item's row blank.
+    """
+
+    def test_list_item_recovers_text_from_inline_group(self):
+        doc, list_item = _doc_with_inline_group_list_item()
+
+        assert list_item.text == ""
+        text = extract_item_text(list_item, doc)
+        assert text is not None
+        assert "Run" in text
+        assert "pytest" in text
+        assert "to test." in text
+
+    def test_extract_items_stores_non_empty_text_for_inline_group_item(self):
+        doc, _ = _doc_with_inline_group_list_item()
+        items = extract_items("doc-1", doc)
+
+        list_items = [i for i in items if i.label == "list_item"]
+        assert len(list_items) == 1
+        assert list_items[0].text != ""
+
+    def test_nested_list_group_not_folded_into_parent_text(self):
+        """A second child (a nested ListGroup of sub-items) must not be
+        pulled into the parent's serialized text: those sub-items are
+        walked and stored as their own rows by extract_items already, so
+        including them here would duplicate their content.
+        """
+        doc, list_item = _doc_with_inline_group_list_item(second_child_group=True)
+
+        text = extract_item_text(list_item, doc)
+        assert text is not None
+        assert "Sub-item" not in text
+
+    def test_reuses_passed_serializer(self, monkeypatch):
+        import docling_core.transforms.serializer.markdown as md
+
+        count = {"n": 0}
+        base = md.MarkdownDocSerializer
+
+        class Counting(base):
+            def __init__(self, *args, **kwargs):
+                count["n"] += 1
+                super().__init__(*args, **kwargs)
+
+        doc, _ = _doc_with_inline_group_list_item()
+        monkeypatch.setattr(md, "MarkdownDocSerializer", Counting)
+
+        items = extract_items("doc-1", doc)
+        assert any(i.label == "list_item" and i.text for i in items)
+        assert count["n"] == 1
+
+    def test_returns_none_when_serialization_fails(self):
+        """A serializer that raises leaves the item with no extractable text
+        rather than aborting the extraction pass, matching the table path.
+        """
+        doc, list_item = _doc_with_inline_group_list_item()
+
+        class _Boom:
+            def serialize(self, item):
+                raise RuntimeError("serializer exploded")
+
+        assert extract_item_text(list_item, doc, get_serializer=_Boom) is None
+
+    def test_leaf_item_without_children_still_returns_none(self):
+        """A genuinely empty item (no text, no children) is unaffected:
+        this is not the InlineGroup case and must not be treated as one.
+        """
+        from docling_core.types.doc.document import DoclingDocument
+        from docling_core.types.doc.labels import DocItemLabel
+
+        doc = DoclingDocument(name="empty-leaf")
+        item = doc.add_text(label=DocItemLabel.PARAGRAPH, text="")
+        assert item.children == []
+        assert extract_item_text(item, doc) is None
+
+    async def test_import_document_recovers_inline_group_text_without_moving_refs(
+        self, temp_db_path
+    ):
+        """import_document stores the caller's DoclingDocument and chunks as
+        given, never converting or flattening it, so a chunk's doc_item_refs
+        index into that document directly. This is the path #621's
+        conversion-time flatten does not reach, and the one the recovered
+        text needs to survive without renumbering anything.
+        """
+        from haiku.rag.config import get_config
+        from haiku.rag.store.models.chunk import Chunk
+
+        doc, list_item = _doc_with_inline_group_list_item()
+        dim = get_config().embeddings.model.vector_dim
+        chunks = [
+            Chunk(
+                content="Run `pytest` to test.",
+                metadata={"doc_item_refs": [list_item.self_ref]},
+                order=0,
+                embedding=[0.1] * dim,
+            )
+        ]
+
+        async with HaikuRAG(temp_db_path, create=True) as client:
+            imported = await client.import_document(
+                doc, chunks, uri="mem://import-inline"
+            )
+
+            items = await client.document_item_repository.get_all_items(imported.id)
+            by_ref = {item.self_ref: item for item in items}
+
+            recovered = by_ref[list_item.self_ref]
+            assert "Run" in recovered.text
+            assert "pytest" in recovered.text
+            assert "to test." in recovered.text
+
+            # The tradeoff ggozad asked to have written down: the group's
+            # own children are still stored as their own rows, since this
+            # path stores the document as given, so the recovered item and
+            # its fragments both land in expanded context.
+            fragment_texts = {
+                item.text for ref, item in by_ref.items() if ref != list_item.self_ref
+            }
+            assert {"Run ", "pytest", " to test."} <= fragment_texts
+
+            stored_chunk = (
+                await client.chunk_repository.get_by_document_id(imported.id)
+            )[0]
+            assert stored_chunk.metadata["doc_item_refs"] == [list_item.self_ref]
+
+
 class TestExtractItemTextFallbacks:
     def test_table_returns_none_when_serialization_fails(self):
         """A serializer that raises leaves the table with no extractable text


### PR DESCRIPTION
Rescoped this to `import_document`/`import_documents`, per your comment: they store the caller's `DoclingDocument` and chunks as given, so a chunk's `doc_item_refs` index into it directly, and #621's flatten only runs at conversion time. A heading or list item docling pushed into a child `InlineGroup` still landed with an empty `document_items` row there. `extract_item_text` recovers it from that group, without touching any refs.

The group's own child rows still get stored too, so the recovered item and its fragments both land in expanded context. That tradeoff is now in the CHANGELOG entry.

Fixed the docstring on `_doc_with_inline_group_list_item`: it claimed the hand-built shape matches any paragraph, heading, or list item. A body-level paragraph's group hangs off `#/body` with no owner item, so that part was wrong.

Added `test_import_document_recovers_inline_group_text_without_moving_refs`, through `client.import_document` rather than `extract_item_text` directly. It builds a list item with an `InlineGroup` child by hand, imports it with a chunk whose `doc_item_refs` cites the list item, and checks the recovered text plus the untouched ref. Pulled the `InlineGroup` branch out locally first to confirm this test fails without it, then restored it: `tests/store/test_document_items.py`, 48 passed. `ruff check` and `ty check` clean on the touched files.

Dropped `Fixes #615` from the title and commit, it's `Refs #615` now, since #621 is what closes it.

One heads-up: #621's diff also lands in this same `### Fixed` block under `[Unreleased]`, cutting a `0.83.0` release there, so whichever of these merges second will need a routine rebase on `CHANGELOG.md`.
