### PR TITLE
Cap sandbox stdout as it accumulates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [Unreleased]
 
-## [0.83.0] - 2026-09-09
+### Fixed
+
+- The sandbox holds at most `analysis.max_output_chars` of a program's printed output while it runs.
 
 ## [0.83.0] - 2026-09-09
 
@@ -2496,7 +2498,6 @@ Existing documents without DoclingDocument data will work but won't have provena
 - Initial version tracking
 
 [Unreleased]: https://github.com/ggozad/haiku.rag/compare/0.83.0...HEAD
-[0.83.0]: https://github.com/ggozad/haiku.rag/compare/0.83.0...0.83.0
 [0.83.0]: https://github.com/ggozad/haiku.rag/compare/0.82.1...0.83.0
 [0.82.1]: https://github.com/ggozad/haiku.rag/compare/0.82.0...0.82.1
 [0.82.0]: https://github.com/ggozad/haiku.rag/compare/0.81.0...0.82.0

--- a/haiku_rag_slim/haiku/rag/sandbox/sandbox.py
+++ b/haiku_rag_slim/haiku/rag/sandbox/sandbox.py
@@ -42,6 +42,29 @@ class SandboxResult:
     success: bool
 
 
+class CappedOutput:
+    """Collects what a program prints, holding no more than `max_chars`."""
+
+    def __init__(self, max_chars: int) -> None:
+        self.max_chars = max_chars
+        self.parts: list[str] = []
+        self.size = 0
+        self.truncated = False
+
+    def write(self, _stream: Literal["stdout", "stderr"], text: str) -> None:
+        room = self.max_chars - self.size
+        if len(text) > room:
+            self.truncated = True
+            text = text[:room]
+        if text:
+            self.parts.append(text)
+            self.size += len(text)
+
+    def text(self) -> str:
+        text = "".join(self.parts)
+        return text + "\n... (output truncated)" if self.truncated else text
+
+
 def recovery_hint(stderr: str) -> str:
     """Name the workaround for sandbox limits models trip over repeatedly.
 
@@ -659,26 +682,16 @@ class Sandbox:
         session, vfs = await self._ensure_initialized()
         external_fns = self._build_external_functions()
 
-        stdout_lines: list[str] = []
-
-        def print_callback(  # pragma: no cover - runs on Monty's worker thread
-            _stream: Literal["stdout", "stderr"], text: str
-        ) -> None:
-            stdout_lines.append(text)
-
-        max_chars = self._config.analysis.max_output_chars
+        out = CappedOutput(self._config.analysis.max_output_chars)
 
         try:
             output = await session.feed_run(
                 code,
                 external_lookup=external_fns,
-                print_callback=print_callback,
+                print_callback=out.write,
                 os=vfs,
             )
         except (pydantic_monty.MontyError, RuntimeError) as e:
-            stdout = "".join(stdout_lines)
-            if len(stdout) > max_chars:
-                stdout = stdout[:max_chars] + "\n... (output truncated)"
             stderr = str(e)
             # A crash kills the worker, and a protocol error leaves it out of
             # step. Both poison the session. Bad user code does not.
@@ -688,17 +701,8 @@ class Sandbox:
                     f"{stderr}\n\nThe interpreter restarted. Variables from "
                     "earlier calls are gone."
                 )
-            return SandboxResult(stdout=stdout, stderr=stderr, success=False)
+            return SandboxResult(stdout=out.text(), stderr=stderr, success=False)
 
-        stdout = "".join(stdout_lines)
         if output is not None:
-            stdout_with_output = f"{stdout}{output}" if stdout else str(output)
-        else:
-            stdout_with_output = stdout
-
-        if len(stdout_with_output) > max_chars:
-            stdout_with_output = (
-                stdout_with_output[:max_chars] + "\n... (output truncated)"
-            )
-
-        return SandboxResult(stdout=stdout_with_output, stderr="", success=True)
+            out.write("stdout", str(output))
+        return SandboxResult(stdout=out.text(), stderr="", success=True)

--- a/tests/sandbox/test_sandbox.py
+++ b/tests/sandbox/test_sandbox.py
@@ -7,6 +7,7 @@ import pytest
 from haiku.rag.client import HaikuRAG
 from haiku.rag.config.models import AppConfig
 from haiku.rag.sandbox import AnalysisContext, Sandbox, SandboxResult
+from haiku.rag.sandbox.sandbox import CappedOutput
 from haiku.rag.store.models.chunk import Chunk
 
 
@@ -379,6 +380,44 @@ class TestSandboxOutputTruncation:
             assert result.success
             assert result.stdout.endswith("... (output truncated)")
             assert len(result.stdout) < 100
+
+    @pytest.mark.asyncio
+    async def test_many_small_prints_past_the_cap_still_report_truncation(
+        self, temp_db_path
+    ):
+        """No single print exceeds the cap, their sum does."""
+        async with HaikuRAG(temp_db_path, create=True):
+            config = AppConfig()
+            config.analysis.max_output_chars = 20
+            context = AnalysisContext()
+            sb = Sandbox(db_path=temp_db_path, config=config, context=context)
+            result = await sb.execute("for i in range(100):\n    print('c' * 5)")
+            assert result.success
+            assert result.stdout.startswith("c" * 5)
+            assert result.stdout.endswith("... (output truncated)")
+            assert len(result.stdout) == 20 + len("\n... (output truncated)")
+
+
+class TestCappedOutput:
+    def test_holds_at_most_the_cap(self):
+        out = CappedOutput(10)
+        for _ in range(1000):
+            out.write("stdout", "abcdef")
+        assert sum(len(p) for p in out.parts) == 10
+        assert len(out.parts) == 2
+        assert out.text() == "abcdefabcd\n... (output truncated)"
+
+    def test_short_output_is_returned_whole(self):
+        out = CappedOutput(10)
+        out.write("stdout", "abc")
+        out.write("stdout", "def")
+        assert out.text() == "abcdef"
+
+    def test_fragment_crossing_the_cap_is_cut(self):
+        out = CappedOutput(10)
+        out.write("stdout", "abcdef")
+        out.write("stdout", "ghijkl")
+        assert out.text() == "abcdefghij\n... (output truncated)"
 
 
 class TestSandboxVFS:


### PR DESCRIPTION
Fixes #623.

`CappedOutput` holds at most `analysis.max_output_chars` of a program's printed output and adds the truncation notice when anything was cut.

Issue reproduction (200 MB printed, cap 50,000): host peak RSS growth 443.5 MB → 0.0 MB. Returned output unchanged: 50,023 chars, notice present.

Also removes the duplicated `## [0.83.0]` header and the `0.83.0...0.83.0` compare link from the CHANGELOG.
