### PR TITLE
Route visualize_chunk to the database a chunk came from

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,7 +197,7 @@ async with HaikuRAG(db_path, config, create=True) as rag:
     await rag.store.delete_tag("release-1")
 
     # Visualization
-    images = await rag.visualize_chunk(chunk)
+    images = await rag.visualize_chunk(chunk, source=result.source)  # source required over a set
     # Coverage (see "Multiple Databases")
     rag.covers_multiple      # more than one database
     rag.source_names         # configured names covered, in order

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   capabilities, naming the configured databases the capability covers. Refused
   beside `db_path` or `rag=` with `AmbiguousDatabaseError`.
 - `storage.compaction_target_bytes` (default 2 GiB): target size for the fragments compaction writes on the tables holding docling blobs.
+- `source` on `HaikuRAG.visualize_chunk`, naming the database the chunk came from. Without one a client covering a set raises `AmbiguousDatabaseError`.
 
 ### Changed
 

--- a/docs/configuration/storage.md
+++ b/docs/configuration/storage.md
@@ -253,7 +253,7 @@ IDs are unique within a database, not across databases. Copies of a database the
 
 Citation ambiguity is evaluated against evidence available to the run. A cited chunk ID is rejected with `AmbiguousCitationError` if search returned it from multiple databases, or it was previously cited from another database. If only one retrieved result has the ID, that result is cited. For an ID absent from search results, the fallback checks every selected database and rejects multiple holders. A shared ID that nothing cites is ignored.
 
-`get_document_by_id`, `get_chunk_by_id` and `get_picture_bytes` take an optional `source`, and ask that database alone. A name the client does not cover raises `UnknownDatabaseError`. Without one, the document and chunk lookups ask every covered database and answer from the first that holds the ID; `get_picture_bytes` requires one whenever the client covers a set.
+`get_document_by_id`, `get_chunk_by_id`, `get_picture_bytes` and `visualize_chunk` take an optional `source`, and ask that database alone. A name the client does not cover raises `UnknownDatabaseError`. Without one, the document and chunk lookups ask every covered database and answer from the first that holds the ID; `get_picture_bytes` and `visualize_chunk` require one whenever the client covers a set, since a chunk carries no database identity where `SearchResult.source` and `Citation.source` do.
 
 The analysis sandbox rejects shared document IDs because its mount path is `/documents/{id}/`.
 

--- a/haiku_rag_slim/haiku/rag/client/__init__.py
+++ b/haiku_rag_slim/haiku/rag/client/__init__.py
@@ -947,9 +947,35 @@ class HaikuRAG:
         chunk: Chunk | Sequence[Chunk],
         refs: list[str] | None = None,
         expand: bool = True,
+        source: str | None = None,
     ) -> list:
+        """Render page images highlighting one or more chunks.
+
+        Args:
+            chunk: The chunk, or the chunks of a merged result.
+            refs: The `doc_item_refs` the model saw, drawn instead of
+                re-expanding.
+            expand: Without `refs`, whether to re-expand the chunks' context.
+            source: The database they came from, which this client must cover.
+                Required when covering a set: a chunk carries no database
+                identity, where `SearchResult.source` and `Citation.source` do.
+
+        Raises:
+            UnknownDatabaseError: If `source` names a database this client does
+                not cover.
+            AmbiguousDatabaseError: If this client covers a set and no `source`
+                names one of them.
+        """
         from haiku.rag.client.search import visualize_chunk
 
+        if source is not None:
+            (owner,) = await self.clients_covering([source])
+            return await owner.visualize_chunk(chunk, refs, expand)
+        if self.covers_multiple:
+            raise AmbiguousDatabaseError(
+                "visualizing a chunk needs the source it came from; this "
+                f"client covers {', '.join(sorted(self.source_names))}"
+            )
         return await visualize_chunk(
             self._single_session("visualize_chunk"), chunk, refs, expand
         )

--- a/tests/multi_db/test_expansion.py
+++ b/tests/multi_db/test_expansion.py
@@ -1,10 +1,13 @@
 """Expanding and enriching results through the database each came from."""
 
 import pytest
+from docling_core.types.doc.document import DoclingDocument
 from pydantic_ai import ModelRetry
 
 from haiku.rag.capabilities.rag import create_capability
 from haiku.rag.client import HaikuRAG
+from haiku.rag.config import get_config
+from haiku.rag.store.exceptions import AmbiguousDatabaseError
 from haiku.rag.store.models import Chunk, Document, DocumentItem, SearchResult
 from tests.multi_db.helpers import (
     _config,
@@ -244,3 +247,68 @@ class TestFederatedEdges:
         with patch.object(RAGCapability, "_ensure_rag", AsyncMock(return_value=orphan)):
             with pytest.raises(ModelRetry, match="None of the supplied chunk_ids"):
                 await run._cite(["orphan"])
+
+
+class TestVisualizationRouting:
+    @staticmethod
+    def _visualizable(name):
+        """A one-page document whose only item has a bounding box to draw."""
+        from docling_core.types.doc.base import BoundingBox, Size
+        from docling_core.types.doc.document import ImageRef, ProvenanceItem
+        from docling_core.types.doc.labels import DocItemLabel
+        from PIL import Image as PilImageModule
+
+        doc = DoclingDocument(name=name)
+        doc.add_page(
+            page_no=1,
+            size=Size(width=612.0, height=792.0),
+            image=ImageRef.from_pil(
+                PilImageModule.new("RGB", (612, 792), color="white"), dpi=72
+            ),
+        )
+        doc.add_text(
+            label=DocItemLabel.PARAGRAPH,
+            text=f"{name} content",
+            prov=ProvenanceItem(
+                page_no=1,
+                bbox=BoundingBox(l=50, t=700, r=550, b=650),
+                charspan=(0, len(name) + 8),
+            ),
+        )
+        return doc
+
+    @pytest.mark.asyncio
+    async def test_a_chunk_is_visualized_by_the_database_that_holds_it(self, tmp_path):
+        """A chunk carries no database identity, so the source the caller holds
+        is what reaches the pages and bounding boxes."""
+        config = _config(tmp_path, ["alpha", "beta"])
+        await _seed(config, "alpha", ["alpha document about cats"])
+        dim = get_config().embeddings.model.vector_dim
+        async with HaikuRAG(config=config, create=True, sources=["beta"]) as beta:
+            document = await beta.import_document(
+                self._visualizable("beta"),
+                [
+                    Chunk(
+                        content="beta content",
+                        embedding=[0.1] * dim,
+                        order=0,
+                        metadata={"doc_item_refs": ["#/texts/0"], "page_numbers": [1]},
+                    )
+                ],
+                uri="test://beta/visualizable",
+            )
+            [chunk] = await beta.chunk_repository.get_by_document_id(document.id)
+
+        async with HaikuRAG(config=config) as rag:
+            assert len(await rag.visualize_chunk(chunk, source="beta")) == 1
+            assert await rag.visualize_chunk(chunk, source="alpha") == []
+
+    @pytest.mark.asyncio
+    async def test_visualizing_without_a_source_is_refused(self, tmp_path):
+        """Federating, nothing in a chunk says which database drew it."""
+        config = _config(tmp_path, ["alpha", "beta"])
+        await _seed(config, "alpha", ["alpha document about cats"])
+
+        async with HaikuRAG(config=config) as rag:
+            with pytest.raises(AmbiguousDatabaseError, match="source"):
+                await rag.visualize_chunk(Chunk(content="x", document_id="doc-1"))


### PR DESCRIPTION
Closes #606.

`visualize_chunk(chunk, refs=None, expand=True, source=None)`. `source` resolves through `clients_covering([source])` and runs on that database's client, as `get_document_by_id`, `get_chunk_by_id` and `get_picture_bytes` do. Unknown name raises `UnknownDatabaseError`; no `source` over a set keeps raising `AmbiguousDatabaseError`, message now names `source`.

No fan-out without a `source`: each attempt decompresses a docling blob and renders page rasters, and a document id shared between copies renders the wrong pages. Same reason `get_picture_bytes` refuses.

Tests: `tests/multi_db/test_expansion.py::TestVisualizationRouting`, two cases — routed (`source="beta"` 1 image, `source="alpha"` `[]`) and refused. `tests/multi_db` 187 passed, `test_search.py`/`test_client.py`/`tests/chat` 176 passed.
