### PR TITLE
Clarify what filter scopes and what bounds a run

### DIFF
--- a/docs/capabilities/index.md
+++ b/docs/capabilities/index.md
@@ -159,4 +159,6 @@ An unknown name raises `UnknownDatabaseError`, an empty list `ValueError`. `sour
 
 The `sources` field of the capability [state](#state) selects among the databases the capability covers, for one question. A question naming a database outside that coverage fails when it searches.
 
+`document_filter` in the same state is a SQL WHERE clause over the document columns (see [Filtering Search Results](../python.md#filtering-search-results)). The host sets it, and it persists until the host changes it. It restricts what the capability's searches retrieve and which documents the analysis sandbox mounts, not what a citation can resolve, so evidence from an earlier question stays citable after the filter narrows.
+
 Passing a client through `rag=` bypasses this selection. The capability uses the databases covered by that client and does not close it.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -159,8 +159,10 @@ and `sources` select, and returns what it printed. The program reads
 `/documents/{document_id}/` (`metadata.json`, `content.txt`, `items.jsonl`,
 `chunks.jsonl`, `toc.json`) and can `await search()` and
 `await list_documents()`; the tool description spells out the fields and the
-patterns that matter. Each call is one program: nothing carries over between
-calls, and the sandbox is created and closed per call. A failing program is a
+patterns that matter. Every document `filter` and `sources` admit is mounted
+with its full text, whether or not a search returned it. Each call is one
+program: nothing carries over between calls, and the sandbox is created and
+closed per call. A failing program is a
 tool error carrying the interpreter's message and any output printed before
 it. No model runs on the server. Claude Code moves a call still running after
 about two minutes to a background task.
@@ -187,6 +189,14 @@ metadata LIKE '%"author": "Smith"%'
 uri LIKE '%.pdf'
 title = 'Q3 report'
 ```
+
+`filter` and `sources` are chosen by the client model on each call. What a
+client can reach is bounded by the databases the server was started against,
+not by either parameter: `filter` restricts what `search_documents` and
+`list_documents` return and what `execute_code` mounts, `get_document` and
+`get_document_section` take none, and a document id resolves through them
+whatever filter another call used. Content that must stay out of a client's
+reach belongs in a database the server does not cover.
 
 ### Errors
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -330,6 +330,8 @@ results = await client.search(
 - `created_at`, `updated_at` - Timestamps
 - `metadata` - Document metadata (as string, use LIKE for pattern matching)
 
+A filter restricts what a search retrieves. `ask` and `analyze` apply it to every search of the run, and `analyze` mounts only the documents it admits, each with its full text. It does not restrict citations: a chunk id the model already holds, from an earlier turn of a conversation for example, resolves within the databases the question covers whether or not its document passes the filter. The string reaches the query engine as written, so build it from trusted input only. To bound what a run can reach, cover fewer databases with `sources` (see [Searching Multiple Databases](#searching-multiple-databases) and [Database selection](capabilities/index.md#database-selection)).
+
 ### Image queries
 
 `client.search()` accepts an image instead of a text query when the configured embedder is multimodal (`embeddings.model.multimodal: true` on a vLLM, VoyageAI, or Cohere model). The image is embedded once and the chunks table is searched vector-only. Full-text search and reranking don't apply without a text query.


### PR DESCRIPTION
Docs only.

## Changes

- `docs/python.md`, Filtering Search Results: `filter` restricts what a search retrieves and what `analyze` mounts, not citations. The string reaches the query engine as written. The boundary of a run is the databases it covers (`sources`).
- `docs/capabilities/index.md`, Database Selection: `document_filter` in the capability state, what it scopes and that it persists until the host changes it.
- `docs/mcp.md`, Code: every document `filter` and `sources` admit is mounted with its full text, whether or not a search returned it.
- `docs/mcp.md`, Filters: `filter` and `sources` are chosen by the client model per call. What a client can reach is bounded by the databases the server was started against.

Refs #622, #624.