### PR TITLE
Fetch and cache remote images so HTML corpora carry picture bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Remote image fetching sends a `User-Agent`. `ConversionOptions.fetch_headers`
+  sets the headers for images referenced by URL in HTML input and defaults to
+  identifying haiku.rag; hosts with a user-agent policy answered 403 and docling
+  reported it as a warning, so the pictures arrived with no bytes. docling's
+  Markdown backend takes no headers.
+
 ## [0.85.0] - 2026-09-11
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Fixed
 
+- FRAMES caches the images its articles reference and inlines them as `data:`
+  URIs, so the corpus carries picture bytes. Parsoid writes protocol-relative
+  `//host/path`, which docling cannot resolve, so every picture was stored
+  empty. Fetches are paced and cached per article with a marker recording what
+  did not resolve.
 - Remote image fetching sends a `User-Agent`. `ConversionOptions.fetch_headers`
   sets the headers for images referenced by URL in HTML input and defaults to
   identifying haiku.rag; hosts with a user-agent policy answered 403 and docling

--- a/evaluations/evaluations/datasets/frames.py
+++ b/evaluations/evaluations/datasets/frames.py
@@ -7,8 +7,11 @@ and fetch date.
 """
 
 import ast
+import base64
+import hashlib
 import json
 import logging
+import mimetypes
 import re
 import time
 from collections.abc import Mapping
@@ -31,6 +34,8 @@ USER_AGENT = "haiku.rag-evaluations (https://github.com/ggozad/haiku.rag)"
 FETCH_ATTEMPTS = 3
 THROTTLE_SECONDS = 1.0
 RATE_LIMIT_BACKOFF_SECONDS = 60.0
+# Measured ceiling for Wikimedia thumbnails. 16 a second draws 429s.
+IMAGE_THROTTLE_SECONDS = 0.125
 
 
 # Articles deleted from Wikipedia since FRAMES was authored; the questions
@@ -198,6 +203,7 @@ def fetch_article(
     if meta_path.exists():
         row = json.loads(meta_path.read_text())
         row["path"] = str(cache_dir / f"{base}.{row['format']}")
+        _cache_article_images(row, cache_dir, client)
         return row
 
     assert client is not None
@@ -231,7 +237,131 @@ def fetch_article(
     content_path.write_text(content)
     meta_path.write_text(json.dumps(row))
     row["path"] = str(content_path)
+    _cache_article_images(row, cache_dir, client)
     return row
+
+
+def _cache_article_images(
+    row: dict[str, Any], cache_dir: Path, client: httpx.Client | None
+) -> None:
+    """Populate the image cache for an HTML article.
+
+    Reads the navigation-stripped HTML, so the interface icons that
+    `strip_navigation` discards are never downloaded.
+    """
+    if row["format"] != "html" or client is None:
+        return
+    html = Path(row["path"]).read_text()
+    fetch_article_images(row["uri"], strip_navigation(html), cache_dir, client)
+
+
+def image_urls(html: str) -> list[str]:
+    """Fetchable image URLs referenced by `html`, in document order, deduped.
+
+    Parsoid writes `//host/path`, which docling cannot resolve without a base.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    urls: list[str] = []
+    seen: set[str] = set()
+    for img in soup.find_all("img"):
+        src = str(img.get("src") or "")
+        if src.startswith("//"):
+            src = f"https:{src}"
+        elif not src.startswith(("http://", "https://")):
+            continue
+        if src not in seen:
+            seen.add(src)
+            urls.append(src)
+    return urls
+
+
+def inline_images(html: str, images: Mapping[str, Path | str]) -> str:
+    """Rewrite each cached `<img src>` to a data: URI over its stored bytes.
+
+    docling decodes inline data: URIs, so conversion reaches no network. An
+    image with no cache entry keeps its unresolvable src.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    for img in soup.find_all("img"):
+        src = str(img.get("src") or "")
+        key = f"https:{src}" if src.startswith("//") else src
+        cached = images.get(key)
+        if cached is None:
+            continue
+        path = Path(cached)
+        mime = mimetypes.guess_type(path.name)[0] or "image/png"
+        encoded = base64.b64encode(path.read_bytes()).decode()
+        img["src"] = f"data:{mime};base64,{encoded}"
+    return str(soup)
+
+
+def _image_path(images_dir: Path, url: str) -> Path:
+    digest = hashlib.sha256(url.encode()).hexdigest()
+    suffix = Path(urlsplit(url).path).suffix.lower()
+    if suffix not in {".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp"}:
+        suffix = ".png"
+    return images_dir / f"{digest}{suffix}"
+
+
+def fetch_article_images(
+    uri: str,
+    html: str,
+    cache_dir: Path,
+    client: httpx.Client | None,
+    throttle: float = IMAGE_THROTTLE_SECONDS,
+    attempts: int = FETCH_ATTEMPTS,
+) -> dict[str, str]:
+    """Cache every image `html` references; return url -> cached path.
+
+    A marker sidecar per article records what resolved and what did not, so a
+    resumed build refetches nothing. An unreachable image is recorded in
+    `failed` rather than discarding the article.
+    """
+    images_dir = cache_dir / "images"
+    images_dir.mkdir(parents=True, exist_ok=True)
+    marker_path = images_dir / f"{quote(uri, safe='')}.json"
+    if marker_path.exists():
+        marker = json.loads(marker_path.read_text())
+        return {url: str(images_dir / name) for url, name in marker["images"].items()}
+
+    if client is None:
+        return {}
+    images: dict[str, str] = {}
+    failed: list[str] = []
+    for url in image_urls(html):
+        target = _image_path(images_dir, url)
+        if target.exists():
+            images[url] = target.name
+            continue
+        for attempt in range(1, attempts + 1):
+            try:
+                time.sleep(throttle)
+                response = client.get(url)
+                response.raise_for_status()
+                target.write_bytes(response.content)
+                images[url] = target.name
+                break
+            except Exception as e:
+                if attempt == attempts:
+                    logger.info(f"Image unavailable for {uri}: {url}: {e}")
+                    failed.append(url)
+                else:
+                    time.sleep(_backoff_seconds(e, attempt))
+
+    marker_path.write_text(
+        json.dumps(
+            {
+                "images": images,
+                "failed": failed,
+                "fetched_at": datetime.now(UTC).date().isoformat(),
+            }
+        )
+    )
+    if failed:
+        logger.warning(
+            f"{len(failed)}/{len(images) + len(failed)} images unavailable for {uri}"
+        )
+    return {url: str(images_dir / name) for url, name in images.items()}
 
 
 def question_expected_uris(doc: Mapping[str, Any]) -> tuple[str, ...]:
@@ -283,6 +413,9 @@ def map_frames_document(doc: Mapping[str, Any]) -> DocumentPayload:
     content = Path(doc["path"]).read_text()
     if doc["format"] == "html":
         content = strip_navigation(content)
+        content = inline_images(
+            content, fetch_article_images(doc["uri"], content, get_cache_dir(), None)
+        )
     metadata: dict[str, str] = {"fetched_at": doc["fetched_at"]}
     if doc.get("revid"):
         metadata["revid"] = doc["revid"]

--- a/evaluations/tests/test_frames.py
+++ b/evaluations/tests/test_frames.py
@@ -1,0 +1,175 @@
+import base64
+import json
+from pathlib import Path
+from typing import cast
+
+import httpx
+import pytest
+
+from evaluations.datasets.frames import (
+    fetch_article_images,
+    image_urls,
+    inline_images,
+)
+
+HTML = """
+<html><body>
+  <img src="//thumb.wikimedia.org/a/logo.png" alt="logo">
+  <img src="//thumb.wikimedia.org/a/logo.png" alt="same again">
+  <img src="https://example.com/absolute.jpg">
+  <img src="/w/relative.png">
+  <img src="data:image/png;base64,AAAA">
+  <img alt="no src at all">
+</body></html>
+"""
+
+
+class StubResponse:
+    def __init__(self, content=b"", status=200, headers=None):
+        self.content = content
+        self.status_code = status
+        self.headers = headers or {}
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class StubClient:
+    """Records every URL asked for and answers from a script."""
+
+    def __init__(self, answers):
+        self.answers = answers
+        self.seen: list[str] = []
+
+    def get(self, url, **kw):
+        self.seen.append(url)
+        return self.answers.get(url, StubResponse(status=404))
+
+
+def test_image_urls_absolutises_protocol_relative_and_dedupes():
+    """Parsoid emits `//host/path`, which docling cannot resolve without a
+    base, so it never fetches and every picture lands without bytes."""
+    assert image_urls(HTML) == [
+        "https://thumb.wikimedia.org/a/logo.png",
+        "https://example.com/absolute.jpg",
+    ]
+
+
+def test_image_urls_skips_relative_and_data_and_missing():
+    """Only fetchable remote refs are returned."""
+    urls = image_urls(HTML)
+    assert not any(u.startswith("data:") for u in urls)
+    assert not any(u.endswith("/w/relative.png") for u in urls)
+
+
+def test_inline_images_rewrites_to_data_uris(tmp_path):
+    png = tmp_path / "logo.png"
+    png.write_bytes(b"\x89PNG-bytes")
+    out = inline_images(HTML, {"https://thumb.wikimedia.org/a/logo.png": png})
+    expected = base64.b64encode(b"\x89PNG-bytes").decode()
+    assert f"data:image/png;base64,{expected}" in out
+    # both occurrences of the same url are rewritten
+    assert out.count("data:image/png;base64,") == 2 + 1  # two imgs + the literal one
+
+
+def test_inline_images_leaves_uncached_refs_alone(tmp_path):
+    """An image we could not cache keeps its original, unresolvable src, so the
+    result degrades to a picture without bytes rather than a conversion-time
+    fetch that could be rate-limited mid-corpus."""
+    out = inline_images(HTML, {})
+    assert "//thumb.wikimedia.org/a/logo.png" in out
+    assert "https://example.com/absolute.jpg" in out
+
+
+def test_fetch_article_images_caches_and_writes_a_marker(tmp_path):
+    client = StubClient(
+        {
+            "https://thumb.wikimedia.org/a/logo.png": StubResponse(b"\x89PNG-1"),
+            "https://example.com/absolute.jpg": StubResponse(b"\xff\xd8JPEG"),
+        }
+    )
+    images = fetch_article_images(
+        "https://en.wikipedia.org/wiki/X",
+        HTML,
+        tmp_path,
+        cast(httpx.Client, client),
+        throttle=0,
+    )
+    assert set(images) == {
+        "https://thumb.wikimedia.org/a/logo.png",
+        "https://example.com/absolute.jpg",
+    }
+    assert all(Path(p).read_bytes() for p in images.values())
+    marker = tmp_path / "images" / "https%3A%2F%2Fen.wikipedia.org%2Fwiki%2FX.json"
+    assert marker.exists()
+    assert json.loads(marker.read_text())["failed"] == []
+
+
+def test_fetch_article_images_serves_a_second_call_from_cache(tmp_path):
+    client = StubClient(
+        {
+            "https://thumb.wikimedia.org/a/logo.png": StubResponse(b"\x89PNG-1"),
+            "https://example.com/absolute.jpg": StubResponse(b"\xff\xd8JPEG"),
+        }
+    )
+    uri = "https://en.wikipedia.org/wiki/X"
+    fetch_article_images(uri, HTML, tmp_path, cast(httpx.Client, client), throttle=0)
+    first = len(client.seen)
+    again = fetch_article_images(
+        uri, HTML, tmp_path, cast(httpx.Client, client), throttle=0
+    )
+    assert len(client.seen) == first, "a cached article must not refetch"
+    assert set(again) == {
+        "https://thumb.wikimedia.org/a/logo.png",
+        "https://example.com/absolute.jpg",
+    }
+
+
+def test_fetch_article_images_records_failures_without_losing_the_article(tmp_path):
+    """One 404 icon must not discard an article, but the loss has to be on the
+    record: a silently partial corpus is the failure this dataset already had."""
+    client = StubClient(
+        {"https://thumb.wikimedia.org/a/logo.png": StubResponse(b"\x89PNG-1")}
+    )
+    images = fetch_article_images(
+        "https://en.wikipedia.org/wiki/X",
+        HTML,
+        tmp_path,
+        cast(httpx.Client, client),
+        throttle=0,
+        attempts=1,
+    )
+    assert set(images) == {"https://thumb.wikimedia.org/a/logo.png"}
+    marker = json.loads(
+        (
+            tmp_path / "images" / "https%3A%2F%2Fen.wikipedia.org%2Fwiki%2FX.json"
+        ).read_text()
+    )
+    assert marker["failed"] == ["https://example.com/absolute.jpg"]
+
+
+def test_fetch_article_images_paces_requests(monkeypatch, tmp_path):
+    """8 req/s is the measured ceiling from the build host; 16 draws 429s."""
+    slept: list[float] = []
+    monkeypatch.setattr("evaluations.datasets.frames.time.sleep", slept.append)
+    client = StubClient(
+        {
+            "https://thumb.wikimedia.org/a/logo.png": StubResponse(b"a"),
+            "https://example.com/absolute.jpg": StubResponse(b"b"),
+        }
+    )
+    fetch_article_images(
+        "https://en.wikipedia.org/wiki/X",
+        HTML,
+        tmp_path,
+        cast(httpx.Client, client),
+        throttle=0.125,
+    )
+    assert slept == [0.125, 0.125]
+
+
+@pytest.mark.parametrize("size", [1, 2])
+def test_image_urls_is_stable_across_calls(size):
+    """Order is document order, so a cache key never depends on iteration luck."""
+    assert image_urls(HTML) == image_urls(HTML)

--- a/haiku_rag_slim/haiku/rag/config/models.py
+++ b/haiku_rag_slim/haiku/rag/config/models.py
@@ -252,6 +252,10 @@ class PictureDescriptionConfig(ConfigModel):
     max_tokens: int = Field(default=200, gt=0)
 
 
+DEFAULT_FETCH_USER_AGENT = "haiku.rag (+https://github.com/ggozad/haiku.rag)"
+"""Hosts with a user-agent policy require an agent naming a contact URL."""
+
+
 class ConversionOptions(ConfigModel):
     """Options for document conversion."""
 
@@ -284,6 +288,11 @@ class ConversionOptions(ConfigModel):
     # Fetch images referenced by URL in HTML and Markdown inputs.
     # docling-local only — docling-serve cannot fetch external images.
     fetch_remote_images: bool = True
+
+    # Hosts with a user-agent policy answer 403 to a library-default agent.
+    fetch_headers: dict[str, str] = Field(
+        default_factory=lambda: {"User-Agent": DEFAULT_FETCH_USER_AGENT}
+    )
 
     picture_description: PictureDescriptionConfig = Field(
         default_factory=PictureDescriptionConfig

--- a/haiku_rag_slim/haiku/rag/converters/docling_local.py
+++ b/haiku_rag_slim/haiku/rag/converters/docling_local.py
@@ -210,7 +210,8 @@ class DoclingLocalConverter(DocumentConverter):
         Every wired FormatOption gets the same `PdfPipelineOptions` instance so
         picture-description / classification / chart settings apply uniformly
         across PDF, IMAGE, HTML, MD, DOCX, PPTX. HTML and Markdown additionally
-        receive backend options gated on `fetch_remote_images`.
+        receive backend options gated on `fetch_remote_images`. Only the HTML
+        backend takes `headers`.
 
         Args:
             source_uri: Origin URI used by the HTML and Markdown backends to
@@ -239,6 +240,7 @@ class DoclingLocalConverter(DocumentConverter):
             pipeline_options = self._build_pipeline_options()
         fetch = opts.fetch_remote_images
         source_url = AnyUrl(source_uri) if source_uri else None
+        headers = dict(opts.fetch_headers) or None
 
         return {
             InputFormat.PDF: PdfFormatOption(
@@ -252,6 +254,7 @@ class DoclingLocalConverter(DocumentConverter):
                     fetch_images=fetch,
                     enable_remote_fetch=fetch,
                     source_uri=source_url,
+                    headers=headers,
                 ),
             ),
             InputFormat.MD: MarkdownFormatOption(

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -733,6 +733,47 @@ class TestDoclingLocalConverter:
         assert md_bo.fetch_images is False
         assert md_bo.enable_remote_fetch is False
 
+    def test_build_format_options_sends_a_default_user_agent(self, config):
+        """Remote image fetching carries a descriptive User-Agent by default.
+
+        Wikimedia and other CDNs answer 403 to an absent or library-default
+        agent, which docling reports only as a warning, so every picture
+        silently arrives without bytes.
+        """
+        from docling.datamodel.backend_options import (
+            HTMLBackendOptions,
+            MarkdownBackendOptions,
+        )
+        from docling.datamodel.base_models import InputFormat
+
+        opts = DoclingLocalConverter(config)._build_format_options()
+        html_bo = opts[InputFormat.HTML].backend_options
+        md_bo = opts[InputFormat.MD].backend_options
+        assert isinstance(html_bo, HTMLBackendOptions)
+        assert isinstance(md_bo, MarkdownBackendOptions)
+        agent = (html_bo.headers or {}).get("User-Agent")
+        assert agent, "remote image fetch must identify itself"
+        assert "haiku.rag" in agent
+        # docling's Markdown backend has no headers field and drops the keyword
+        # silently, so markdown remote images cannot carry an agent yet.
+        assert "headers" not in type(md_bo).model_fields
+
+    def test_build_format_options_merges_configured_fetch_headers(self, config):
+        """`fetch_headers` reaches the HTML backend, and overrides the default."""
+        from docling.datamodel.backend_options import HTMLBackendOptions
+        from docling.datamodel.base_models import InputFormat
+
+        config.processing.conversion_options.fetch_headers = {
+            "User-Agent": "mine/1.0",
+            "Referer": "https://example.com/",
+        }
+        opts = DoclingLocalConverter(config)._build_format_options()
+        html_bo = opts[InputFormat.HTML].backend_options
+        assert isinstance(html_bo, HTMLBackendOptions)
+        headers = html_bo.headers or {}
+        assert headers["User-Agent"] == "mine/1.0"
+        assert headers["Referer"] == "https://example.com/"
+
     def test_build_format_options_threads_source_uri(self, config):
         """`_build_format_options(source_uri=...)` plumbs the URI into the
         HTML and Markdown backend options so docling can resolve relative


### PR DESCRIPTION
Two blockers stopped remote images from reaching a database from HTML input. Neither fix alone changes anything.

**1. No `User-Agent`.** Hosts with a user-agent policy answer 403 to docling's default, and docling reports the refusal as a warning, so pictures were stored without bytes and no ingest failed. Measured: empty, `python-requests/2.32.3` and `python-httpx/0.27.0` all 403; a descriptive agent 200.

`ConversionOptions.fetch_headers` sets the headers, defaulting to `haiku.rag (+https://github.com/ggozad/haiku.rag)`. Only docling's `HTMLBackendOptions` takes `headers`; `MarkdownBackendOptions` has no such field and drops the keyword, which a test pins.

**2. Parsoid writes protocol-relative `//host/path`.** docling has no base to resolve it, so no fetch is attempted. `frames.py` absolutises and dedupes what an article references, caches it under `cache_dir/images/` with a marker per article, and inlines the bytes as `data:` URIs. Conversion then reaches no network and cannot be throttled part-way through a corpus. Images are read from the navigation-stripped HTML, so icons `strip_navigation` discards are never downloaded.

Pacing is `IMAGE_THROTTLE_SECONDS = 0.125`. Measured from the build host: 1, 2, 4 and 8 req/s clean, 16 req/s returns 4.2% 429s with `Retry-After: 11`.

An unreachable image is recorded in the marker's `failed` list rather than discarding the article.

## Verification

- `pytest -m "not integration" --cov=haiku`: 2897 passed, 100.00% coverage
- `evaluations/`: 290 passed
- Mutation checks: removing `headers=headers` fails 2 tests; removing the `//` rewrite fails 5
- Negative control: clearing `fetch_headers` returns 113 pictures to 0 with bytes
- 10 real articles, 362 images, 0 failures; a `Category:` page is `format: md` and correctly skipped; a second pass over the cache reaches no network